### PR TITLE
enable win32 compilation

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -45,6 +45,39 @@
           "oci_lib_dir%" : "<!(if [ -z $OCI_LIB_DIR ]; then echo \"/opt/oracle/instantclient_12_1/\"; else echo $OCI_LIB_DIR; fi)",
         }
       }
+    ],
+    [ 
+     'OS!="win"', {
+      "libraries"     : ["-lclntsh"],
+      "link_settings" : {
+         "libraries"  : ['-L<(oci_lib_dir)'] 
+       }
+     }
+    ],
+    [
+      'OS=="win"', {
+        "configurations": {
+          "Release": {
+            "msvs_settings": {
+              "VCCLCompilerTool": {
+                "RuntimeLibrary": "2"
+              }
+            },
+          },
+          "Debug": {
+            "msvs_settings": {
+              "VCCLCompilerTool": {
+                "RuntimeLibrary": "3"
+              }
+            },
+          }
+        },
+        "variables" : {
+          "oci_inc_dir%": "<!(IF DEFINED OCI_INC_DIR (echo %OCI_INC_DIR%) ELSE (echo C:\oracle\instantclient\sdk\include))",
+          "oci_lib_dir%": "<!(IF DEFINED OCI_LIB_DIR (echo %OCI_LIB_DIR%) ELSE (echo C:\oracle\instantclient\sdk\lib\msvc))",
+        },
+        "link_settings": {"libraries": [ '<(oci_lib_dir)\oci.lib'] }
+      }
     ]
     ],
   "cflags"        : ['-fexceptions'],
@@ -53,10 +86,6 @@
                       "src/dpi/src/",
                       "src/dpi/include/"
   ],
-  "libraries"     : ["-lclntsh"],
-  "link_settings" : {
-     "libraries"  : ['-L<(oci_lib_dir)'] 
-    }
   }
   ]
 }

--- a/src/dpi/include/dpiException.h
+++ b/src/dpi/include/dpiException.h
@@ -2,17 +2,17 @@
 
 /******************************************************************************
  *
- * You may not use the identified files except in compliance with the Apache 
+ * You may not use the identified files except in compliance with the Apache
  * License, Version 2.0 (the "License.")
  *
- * You may obtain a copy of the License at 
+ * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software 
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
- * See the License for the specific language governing permissions and 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  *
  * NAME
@@ -62,17 +62,20 @@ class Exception : public exception
  public:
                                 // creation/termination
   Exception(){};
-  
+
   virtual ~Exception() throw();
 
   virtual const char * what() const throw() = 0;
-  
+  // msvc has this as macro
+#ifdef errno
+#undef errno
+#endif
   virtual int    errno() const throw() = 0;
-  
+
   virtual const char * origin() const throw() = 0;
-  
+
 private:
-  
+
 };
 
 


### PR DESCRIPTION
	modified:   binding.gyp
        modified:   src/dpi/include/dpiException.h

Added win32 compilation to binding.gyp
undef errno in dpiException.h as this is a macro in MSVC

Signed-off-by: Rinie Kervel <rinie.kervel@gmail.com>