### PR TITLE
Update webapp.js

### DIFF
--- a/examples/webapp.js
+++ b/examples/webapp.js
@@ -139,8 +139,8 @@ oracledb.createPool (
           });
       });
 
-    process.on('SIGTERM', function () {
-      console.log('Received SIGTERM');
+	var cleanup = function(type) {
+	  console.log('Received ' + type);
       pool.terminate(
         function(err)
         {
@@ -151,7 +151,18 @@ oracledb.createPool (
           console.log('Closed Oracle connection pool');
           process.exit(0);
         });
-    });
+	};
+	
+    process
+		.on('SIGTERM', function() {
+				cleanup('SIGTERM');
+		})
+		
+		.on('SIGINT', function() {
+			if(process.platform == 'win32') {
+				cleanup('SIGINT');
+			}
+		});
     
     hs.listen(portid, "localhost");
     


### PR DESCRIPTION
SIGTERM is not compatible with Windows. As such, the connection pool would never be terminated...

By refactoring the code so that the callback function is defined in a variable, we are able to call it under two separate conditions.
1.) when a SIGTERM is received.
2.) when a SIGINT is received on Windows.

I emailed a signed OC Agreement a few minutes ago.

Signed-off-by: Bill Christo <billchristo@gmail.com>

*more info on SIGNTERM and SIGINT can be found here: http://nodejs.org/api/process.html#process_signal_events