### PR TITLE
fixed link to the example folder in doc/api.md

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -112,7 +112,7 @@ With Oracle's sample HR schema, the output is:
 ```
 
 There are more examples in the
-[examples](https://github.com/oracle/node-oracledb/examples)
+[examples](https://github.com/oracle/node-oracledb/tree/master/examples)
 directory.
 
 ## <a name="errorobj"></a> 2. Errors


### PR DESCRIPTION
Fixed a broken link from doc/api to the example folder.