### PR TITLE
renamed "isAutoCommit" to "autoCommit" in examples

### DIFF
--- a/examples/dmlrupd1.js
+++ b/examples/dmlrupd1.js
@@ -54,7 +54,7 @@ oracledb.getConnection(
         rid:   { type: oracledb.NUMBER, dir: oracledb.BIND_OUT },
         rname: { type: oracledb.STRING, dir: oracledb.BIND_OUT }
       },
-      { isAutoCommit: true },
+      { autoCommit: true },
       function(err, result)
       {
         if (err)

--- a/examples/dmlrupd2.js
+++ b/examples/dmlrupd2.js
@@ -53,7 +53,7 @@ oracledb.getConnection(
         rid:   { type: oracledb.NUMBER, dir: oracledb.BIND_OUT },
         rname: { type: oracledb.STRING, dir: oracledb.BIND_OUT }
       },
-      { isAutoCommit: true },
+      { autoCommit: true },
       function(err, result)
       {
         if (err)


### PR DESCRIPTION
The latest version of the driver uses the "autoCommit" flag, while the examples were still using the old one "isAutoCommit". I renamed it in two examples. 