### PR TITLE
fixed crash when result sets have unsupported types

### DIFF
--- a/src/njs/src/njsResultSet.cpp
+++ b/src/njs/src/njsResultSet.cpp
@@ -332,6 +332,8 @@ void ResultSet::Async_GetRows(uv_work_t *req)
         getRowsBaton-> njsRS-> defineBuffers_ = NULL;
       }
       Connection::DoDefines(ebaton, njsRS->meta_, njsRS->numCols_);
+      if ( !ebaton->error.empty() )
+        goto exitAsyncGetRows;
       njsRS->fetchRowCount_ = getRowsBaton->numRows;
       njsRS->defineBuffers_ = ebaton->defines;
     }


### PR DESCRIPTION
This one was trivial. You can discard if you already fixed it.

Signed-off-by: Bruno Jouhier <bruno.jouhier@sage.com>