### PR TITLE
better explained Visual C++ Redistributable requirement

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -468,8 +468,7 @@ Install a C/C++ build environment such as Microsoft Visual
 Studio 2012.  Compilers supported by Oracle libraries are found in
 Oracle documentation for each version, for example
 [Oracle Database Client Quick Installation Guide 12c Release 1 (12.1) for Microsoft Windows x64 (64-Bit)](https://docs.oracle.com/database/121/NXCQI/toc.htm#NXCQI108).
-You will also need the matching Visual C++ Redistributable for Visual
-Studio.
+If you are moving an already compiled copy of oracledb to another computer, you will need to have Visual C++ 2010 Redistributable installed.
 
 Install the Python 2.7 MSI from
 [www.python.org](https://www.python.org/downloads).  Select the

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -468,7 +468,7 @@ Install a C/C++ build environment such as Microsoft Visual
 Studio 2012.  Compilers supported by Oracle libraries are found in
 Oracle documentation for each version, for example
 [Oracle Database Client Quick Installation Guide 12c Release 1 (12.1) for Microsoft Windows x64 (64-Bit)](https://docs.oracle.com/database/121/NXCQI/toc.htm#NXCQI108).
-If you are moving an already compiled copy of oracledb to another computer, you will need to have Visual C++ 2010 Redistributable installed.
+If you are moving an already compiled copy of oracledb to another computer and you compiled using Visual Studio 2010 *or higher*, you will need to have Visual C++ 2010 Redistributable installed. For anything older, you will need the matching C++ redistributable version. So, for example, if you compiled with Visual Studio 2008, you will need Visual Studio 2008 C++ Redistributable installed.
 
 Install the Python 2.7 MSI from
 [www.python.org](https://www.python.org/downloads).  Select the


### PR DESCRIPTION
node-oracledb only requires Visual C++ Redistributable when a compiler is not installed. Also, the version that seems to be required is 2010 (see https://github.com/oracle/node-oracledb/issues/189#issuecomment-137874533) and not the version that gets installed automatically with the Visual Studio Compiler.