### PR TITLE
fixed oracle/node-oracledb#208 - emit end event before close

### DIFF
--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -64,10 +64,12 @@ Lob.prototype._read = function()
         self.emit('error', err);
         return;
       }
-      if (!str) {
-        self.close();
-      }
       self.push(str);
+      if (!str) {
+        process.nextTick(function() {
+          self.close();
+        });
+      }
     });
 }
 


### PR DESCRIPTION
This is a simple fix to #208. The `null` value must be pushed before emitting the `close` event and the `close` event must postponed with a `process.nextTick` call.