### PR TITLE
fixed oracle/node-oracledb#210 - crash when fetching several rows wit…

### DIFF
--- a/src/njs/src/njsResultSet.cpp
+++ b/src/njs/src/njsResultSet.cpp
@@ -433,6 +433,22 @@ void ResultSet::Async_GetRows(uv_work_t *req)
       }
       njsRS->fetchRowCount_ = getRowsBaton->numRows;
       njsRS->defineBuffers_ = ebaton->defines;
+    } else {
+      for (unsigned int col = 0; col < njsRS->numCols_; col++)
+      {
+        switch(njsRS->meta_[col].dbType)
+        {
+          case dpi::DpiClob:
+          case dpi::DpiBlob:
+          case dpi::DpiBfile:
+            for (unsigned int j = 0; j < ebaton->maxRows; j++)
+            {
+              ((Descriptor **)(njsRS->defineBuffers_[col].buf))[j] = 
+                ebaton->dpienv->allocDescriptor(LobDescriptorType);
+            }
+            break;
+          }
+        }
     }
     ebaton->defines      = njsRS->defineBuffers_;
     Connection::DoFetch(ebaton);


### PR DESCRIPTION
…h lobs

Problem comes from the fact that the descriptors are freed after the first row has been read. I fixed it by reallocating the descriptors before every row.

Not sure that this is the correct fix but at least it gets me going for now.

Note: my code executes a SELECT with `resultSet: true` and then reads every row in turn with `rs.getRow(callback)`.