### PR TITLE
Patch for ORA-24347 when maxRows = number of returned rows and using an aggregate function

### DIFF
--- a/src/dpi/src/dpiUtils.cpp
+++ b/src/dpi/src/dpiUtils.cpp
@@ -58,7 +58,7 @@
 
 static void ociCallCommon(sword rc, void *handle, ub4 errType)
 {
-  if (!rc)
+    if (rc == OCI_SUCCESS || rc == OCI_SUCCESS_WITH_INFO)
     return;
 
   if (rc == OCI_INVALID_HANDLE)


### PR DESCRIPTION
This fixes the Bug#80.

Signed-off-by: Francisco Trevino <ftrevino@gmail.com>