### PR TITLE
fixup! assert dates with milliseconds precission

### DIFF
--- a/test/dataTypeAssist.js
+++ b/test/dataTypeAssist.js
@@ -495,6 +495,8 @@ assist.dataTypeSupport = function(connection, tableName, array, done) {
           result.rows[i].CONTENT.should.eql(array[result.rows[i].NUM]);
         else if( Buffer.isBuffer(result.rows[i].CONTENT) )
           result.rows[i].CONTENT.toString('hex').should.eql(array[result.rows[i].NUM].toString('hex'));
+        else if (Object.prototype.toString.call(result.rows[i].CONTENT) === '[object Date]')
+          result.rows[i].CONTENT.getTime().should.eql(array[result.rows[i].NUM].getTime());
         else
           result.rows[i].CONTENT.toUTCString().should.eql(array[result.rows[i].NUM].toUTCString());
       }   


### PR DESCRIPTION
When asserting dates with milliseconds precission, `32. dataTypeDate.js 32.1 Testing JavaScript Date data 32.1.1 works well with SELECT query` test fails.

I have the same issue in my projects, because dates saved have a small delay of milliseconds in oracle database. These dates are created at the time of the beginning of the day.