### PR TITLE
extended metaData

### DIFF
--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -87,6 +87,122 @@ function extend(oracledb) {
         value: 0,
         enumerable: true
       },
+      DBTYPE_VARCHAR: {
+        value: 1001,
+        enumerable: true
+      },
+      DBTYPE_NUMBER: {
+        value: 1002,
+        enumerable: true
+      },
+      DBTYPE_INTEGER: {
+        value: 1003,
+        enumerable: true
+      },
+      DBTYPE_DOUBLE: {
+        value: 1004,
+        enumerable: true
+      },
+      DBTYPE_STRING: {
+        value: 1005,
+        enumerable: true
+      },
+      DBTYPE_LONG: {
+        value: 1008,
+        enumerable: true
+      },
+      DBTYPE_DATE: {
+        value: 1012,
+        enumerable: true
+      },
+      DBTYPE_RAW: {
+        value: 1023,
+        enumerable: true
+      },
+      DBTYPE_LONGRAW: {
+        value: 1024,
+        enumerable: true
+      },
+      DBTYPE_UNSIGNEDINTEGER: {
+        value: 1068,
+        enumerable: true
+      },
+      DBTYPE_ROWID: {
+        value: 1104,
+        enumerable: true
+      },
+      DBTYPE_FIXEDCHAR: {
+        value: 1096,
+        enumerable: true
+      },
+      DBTYPE_BINARYFLOAT: {
+        value: 1100,
+        enumerable: true
+      },
+      DBTYPE_BINARYDOUBLE: {
+        value: 1101,
+        enumerable: true
+      },
+      DBTYPE_UDT: {
+        value: 1108,
+        enumerable: true
+      },
+      DBTYPE_REF: {
+        value: 1111,
+        enumerable: true
+      },
+      DBTYPE_CLOB: {
+        value: 1112,
+        enumerable: true
+      },
+      DBTYPE_BLOB: {
+        value: 1113,
+        enumerable: true
+      },
+      DBTYPE_BFILE: {
+        value: 1114,
+        enumerable: true
+      },
+      DBTYPE_RSET: {
+        value: 1116,
+        enumerable: true
+      },
+      DBTYPE_YEARMONTH: {
+        value: 1182,
+        enumerable: true
+      },
+      DBTYPE_DAYSECOND: {
+        value: 1183,
+        enumerable: true
+      },
+      DBTYPE_TIMESTAMP: {
+        value: 1187,
+        enumerable: true
+      },
+      DBTYPE_TIMESTAMPTZ: {
+        value: 1188,
+        enumerable: true
+      },
+      DBTYPE_UROWID: {
+        value: 1208,
+        enumerable: true
+      },
+      DBTYPE_TIMESTAMPLTZ: {
+        value: 1232,
+        enumerable: true
+      },
+      DBTYPE_TYPEBASE: {
+        value: 1999,
+        enumerable: true
+      },
+      DBTYPE_DATETIMEARRAY: {
+        value: 1998,
+        enumerable: true
+      },
+      DBTYPE_INTERVALARRAY: {
+        value: 1997,
+        enumerable: true
+      },
       STRING: {
         value: 2001,
         enumerable: true

--- a/src/njs/src/njsConnection.h
+++ b/src/njs/src/njsConnection.h
@@ -170,7 +170,7 @@ typedef struct eBaton
   unsigned int              prefetchRows;
   bool                      getRS;
   bool                      autoCommit;
-  bool                      noMetadata;
+  bool                      metaData;
   unsigned int              rowsFetched;
   unsigned int              outFormat;
   unsigned int              numCols;
@@ -192,7 +192,7 @@ typedef struct eBaton
   eBaton( unsigned int& count, Local<Function> callback ) :
              sql(""), error(""), dpienv(NULL), dpiconn(NULL), njsconn(NULL),
              rowsAffected(0), maxRows(0), prefetchRows(0),
-             getRS(false), autoCommit(false), noMetadata(false), rowsFetched(0),
+             getRS(false), autoCommit(false), metaData(true), rowsFetched(0),
              outFormat(0), numCols(0), dpistmt(NULL),
              st(DpiStmtUnknown), stmtIsReturning (false), numOutBinds(0),
              columnNames(NULL), defines(NULL), fetchAsStringTypesCount (0),

--- a/src/njs/src/njsConnection.h
+++ b/src/njs/src/njsConnection.h
@@ -122,14 +122,14 @@ typedef struct FieldInfo
 {
   std::string       name;                     /* DB Column name */
   std::string       type;                     /* Column data type (js)*/
-  std::string       originalType;             /* Column data type (db type)*/
+  unsigned short    originalType;             /* Column data type (db type)*/
   unsigned int      size;                     /* Size at database */
   unsigned int      precision;                /* Precision */
   unsigned int      scale;                    /* Scale */
   bool              isNullable;               /* Nullable */
   // Constructor to initialize member variables.
   FieldInfo ()
-    : name (""), type (""), originalType (""),
+    : name (""), type (""), originalType (0),
     size(0), precision(0), scale(0), isNullable(false)
   {
   }
@@ -170,6 +170,7 @@ typedef struct eBaton
   unsigned int              prefetchRows;
   bool                      getRS;
   bool                      autoCommit;
+  bool                      noMetadata;
   unsigned int              rowsFetched;
   unsigned int              outFormat;
   unsigned int              numCols;
@@ -191,7 +192,7 @@ typedef struct eBaton
   eBaton( unsigned int& count, Local<Function> callback ) :
              sql(""), error(""), dpienv(NULL), dpiconn(NULL), njsconn(NULL),
              rowsAffected(0), maxRows(0), prefetchRows(0),
-             getRS(false), autoCommit(false), rowsFetched(0), 
+             getRS(false), autoCommit(false), noMetadata(false), rowsFetched(0),
              outFormat(0), numCols(0), dpistmt(NULL),
              st(DpiStmtUnknown), stmtIsReturning (false), numOutBinds(0),
              columnNames(NULL), defines(NULL), fetchAsStringTypesCount (0),
@@ -355,7 +356,7 @@ private:
   static void PrepareAndBind (eBaton* executeBaton);
   
   static unsigned short SourceDBType2TargetDBType ( unsigned srcType );
-  static std::string SourceDBType2String ( unsigned srcType );
+  static unsigned short SourceDBType2DBTYPE ( unsigned srcType );
   static std::string SourceDBType2JSString ( unsigned srcType );
   static boolean MapByName ( eBaton *executeBaton,
                               std::string &name,

--- a/src/njs/src/njsOracle.cpp
+++ b/src/njs/src/njsOracle.cpp
@@ -79,7 +79,7 @@ Oracledb::Oracledb()
   outFormat_          = ROWS_ARRAY;
   maxRows_            = NJS_MAX_ROWS;
   autoCommit_         = false;
-  noMetadata_         = false;
+  metaData_           = true;
   stmtCacheSize_      = NJS_STMT_CACHE_SIZE;
   poolMax_            = NJS_POOL_MAX;
   poolMin_            = NJS_POOL_MIN;
@@ -166,9 +166,9 @@ void Oracledb::Init(Handle<Object> target)
     Oracledb::SetAutoCommit );
   Nan::SetAccessor(
     temp->InstanceTemplate(),
-    Nan::New<v8::String>("noMetadata").ToLocalChecked(),
-    Oracledb::GetNoMetadata,
-    Oracledb::SetNoMetadata );
+    Nan::New<v8::String>("metaData").ToLocalChecked(),
+    Oracledb::GetMetadata,
+    Oracledb::SetMetadata );
   Nan::SetAccessor(
     temp->InstanceTemplate(),
     Nan::New<v8::String>("maxRows").ToLocalChecked(),
@@ -463,25 +463,25 @@ NAN_SETTER(Oracledb::SetAutoCommit)
 /*****************************************************************************/
 /*
    DESCRIPTION
-     Get Accessor of noMetadata property
+     Get Accessor of metaData property
 */
-NAN_GETTER(Oracledb::GetNoMetadata)
+NAN_GETTER(Oracledb::GetMetadata)
 {
   Oracledb* oracledb = Nan::ObjectWrap::Unwrap<Oracledb>(info.Holder());
   NJS_CHECK_OBJECT_VALID2(oracledb, info);
-  info.GetReturnValue().Set(Nan::New<v8::Boolean>(oracledb->noMetadata_));
+  info.GetReturnValue().Set(Nan::New<v8::Boolean>(oracledb->metaData_));
 }
 
 /*****************************************************************************/
 /*
    DESCRIPTION
-     Set Accessor of noMetadata property
+     Set Accessor of metaData property
 */
-NAN_SETTER(Oracledb::SetNoMetadata)
+NAN_SETTER(Oracledb::SetMetadata)
 {
   Oracledb* oracledb = Nan::ObjectWrap::Unwrap<Oracledb>(info.Holder());
   NJS_CHECK_OBJECT_VALID (oracledb);
-  oracledb->noMetadata_ = value->ToBoolean()->Value();
+  oracledb->metaData_ = value->ToBoolean()->Value();
 }
 
 /*****************************************************************************/

--- a/src/njs/src/njsOracle.cpp
+++ b/src/njs/src/njsOracle.cpp
@@ -167,8 +167,8 @@ void Oracledb::Init(Handle<Object> target)
   Nan::SetAccessor(
     temp->InstanceTemplate(),
     Nan::New<v8::String>("metaData").ToLocalChecked(),
-    Oracledb::GetMetadata,
-    Oracledb::SetMetadata );
+    Oracledb::GetMetaData,
+    Oracledb::SetMetaData );
   Nan::SetAccessor(
     temp->InstanceTemplate(),
     Nan::New<v8::String>("maxRows").ToLocalChecked(),
@@ -465,7 +465,7 @@ NAN_SETTER(Oracledb::SetAutoCommit)
    DESCRIPTION
      Get Accessor of metaData property
 */
-NAN_GETTER(Oracledb::GetMetadata)
+NAN_GETTER(Oracledb::GetMetaData)
 {
   Oracledb* oracledb = Nan::ObjectWrap::Unwrap<Oracledb>(info.Holder());
   NJS_CHECK_OBJECT_VALID2(oracledb, info);
@@ -477,7 +477,7 @@ NAN_GETTER(Oracledb::GetMetadata)
    DESCRIPTION
      Set Accessor of metaData property
 */
-NAN_SETTER(Oracledb::SetMetadata)
+NAN_SETTER(Oracledb::SetMetaData)
 {
   Oracledb* oracledb = Nan::ObjectWrap::Unwrap<Oracledb>(info.Holder());
   NJS_CHECK_OBJECT_VALID (oracledb);

--- a/src/njs/src/njsOracle.cpp
+++ b/src/njs/src/njsOracle.cpp
@@ -79,6 +79,7 @@ Oracledb::Oracledb()
   outFormat_          = ROWS_ARRAY;
   maxRows_            = NJS_MAX_ROWS;
   autoCommit_         = false;
+  noMetadata_         = false;
   stmtCacheSize_      = NJS_STMT_CACHE_SIZE;
   poolMax_            = NJS_POOL_MAX;
   poolMin_            = NJS_POOL_MIN;
@@ -163,6 +164,11 @@ void Oracledb::Init(Handle<Object> target)
     Nan::New<v8::String>("autoCommit").ToLocalChecked(),
     Oracledb::GetAutoCommit,
     Oracledb::SetAutoCommit );
+  Nan::SetAccessor(
+    temp->InstanceTemplate(),
+    Nan::New<v8::String>("noMetadata").ToLocalChecked(),
+    Oracledb::GetNoMetadata,
+    Oracledb::SetNoMetadata );
   Nan::SetAccessor(
     temp->InstanceTemplate(),
     Nan::New<v8::String>("maxRows").ToLocalChecked(),
@@ -452,6 +458,30 @@ NAN_SETTER(Oracledb::SetAutoCommit)
   Oracledb* oracledb = Nan::ObjectWrap::Unwrap<Oracledb>(info.Holder());
   NJS_CHECK_OBJECT_VALID (oracledb);
   oracledb->autoCommit_ = value->ToBoolean()->Value();
+}
+
+/*****************************************************************************/
+/*
+   DESCRIPTION
+     Get Accessor of noMetadata property
+*/
+NAN_GETTER(Oracledb::GetNoMetadata)
+{
+  Oracledb* oracledb = Nan::ObjectWrap::Unwrap<Oracledb>(info.Holder());
+  NJS_CHECK_OBJECT_VALID2(oracledb, info);
+  info.GetReturnValue().Set(Nan::New<v8::Boolean>(oracledb->noMetadata_));
+}
+
+/*****************************************************************************/
+/*
+   DESCRIPTION
+     Set Accessor of noMetadata property
+*/
+NAN_SETTER(Oracledb::SetNoMetadata)
+{
+  Oracledb* oracledb = Nan::ObjectWrap::Unwrap<Oracledb>(info.Holder());
+  NJS_CHECK_OBJECT_VALID (oracledb);
+  oracledb->noMetadata_ = value->ToBoolean()->Value();
 }
 
 /*****************************************************************************/

--- a/src/njs/src/njsOracle.h
+++ b/src/njs/src/njsOracle.h
@@ -88,7 +88,7 @@ class Oracledb: public Nan::ObjectWrap
 
    dpi::Env*          getDpiEnv () const          { return dpienv_; }
    bool               getAutoCommit () const      { return autoCommit_; }
-   bool               getNoMetadata () const      { return noMetadata_; }
+   bool               getMetaData () const        { return metaData_; }
    unsigned int       getOutFormat () const       { return outFormat_; }
    unsigned int       getMaxRows ()  const        { return maxRows_; }
    unsigned int       getStmtCacheSize ()  const  { return stmtCacheSize_; }
@@ -127,7 +127,7 @@ private:
    static NAN_GETTER(GetPoolTimeout);
    static NAN_GETTER(GetStmtCacheSize);
    static NAN_GETTER(GetAutoCommit);
-   static NAN_GETTER(GetNoMetadata);
+   static NAN_GETTER(GetMetadata);
    static NAN_GETTER(GetMaxRows);
    static NAN_GETTER(GetOutFormat);
    static NAN_GETTER(GetVersion);
@@ -145,7 +145,7 @@ private:
    static NAN_SETTER(SetPoolTimeout);
    static NAN_SETTER(SetStmtCacheSize);
    static NAN_SETTER(SetAutoCommit);
-   static NAN_SETTER(SetNoMetadata);
+   static NAN_SETTER(SetMetadata);
    static NAN_SETTER(SetMaxRows);
    static NAN_SETTER(SetOutFormat);
    static NAN_SETTER(SetVersion);
@@ -162,7 +162,7 @@ private:
    dpi::Env* dpienv_;
    unsigned int outFormat_;
    bool         autoCommit_;
-   bool         noMetadata_;
+   bool         metaData_;
    unsigned int maxRows_;
 
    unsigned int stmtCacheSize_;

--- a/src/njs/src/njsOracle.h
+++ b/src/njs/src/njsOracle.h
@@ -88,6 +88,7 @@ class Oracledb: public Nan::ObjectWrap
 
    dpi::Env*          getDpiEnv () const          { return dpienv_; }
    bool               getAutoCommit () const      { return autoCommit_; }
+   bool               getNoMetadata () const      { return noMetadata_; }
    unsigned int       getOutFormat () const       { return outFormat_; }
    unsigned int       getMaxRows ()  const        { return maxRows_; }
    unsigned int       getStmtCacheSize ()  const  { return stmtCacheSize_; }
@@ -126,6 +127,7 @@ private:
    static NAN_GETTER(GetPoolTimeout);
    static NAN_GETTER(GetStmtCacheSize);
    static NAN_GETTER(GetAutoCommit);
+   static NAN_GETTER(GetNoMetadata);
    static NAN_GETTER(GetMaxRows);
    static NAN_GETTER(GetOutFormat);
    static NAN_GETTER(GetVersion);
@@ -143,6 +145,7 @@ private:
    static NAN_SETTER(SetPoolTimeout);
    static NAN_SETTER(SetStmtCacheSize);
    static NAN_SETTER(SetAutoCommit);
+   static NAN_SETTER(SetNoMetadata);
    static NAN_SETTER(SetMaxRows);
    static NAN_SETTER(SetOutFormat);
    static NAN_SETTER(SetVersion);
@@ -159,6 +162,7 @@ private:
    dpi::Env* dpienv_;
    unsigned int outFormat_;
    bool         autoCommit_;
+   bool         noMetadata_;
    unsigned int maxRows_;
 
    unsigned int stmtCacheSize_;

--- a/src/njs/src/njsOracle.h
+++ b/src/njs/src/njsOracle.h
@@ -127,7 +127,7 @@ private:
    static NAN_GETTER(GetPoolTimeout);
    static NAN_GETTER(GetStmtCacheSize);
    static NAN_GETTER(GetAutoCommit);
-   static NAN_GETTER(GetMetadata);
+   static NAN_GETTER(GetMetaData);
    static NAN_GETTER(GetMaxRows);
    static NAN_GETTER(GetOutFormat);
    static NAN_GETTER(GetVersion);
@@ -145,7 +145,7 @@ private:
    static NAN_SETTER(SetPoolTimeout);
    static NAN_SETTER(SetStmtCacheSize);
    static NAN_SETTER(SetAutoCommit);
-   static NAN_SETTER(SetMetadata);
+   static NAN_SETTER(SetMetaData);
    static NAN_SETTER(SetMaxRows);
    static NAN_SETTER(SetOutFormat);
    static NAN_SETTER(SetVersion);

--- a/src/njs/src/njsResultSet.cpp
+++ b/src/njs/src/njsResultSet.cpp
@@ -431,7 +431,7 @@ void ResultSet::Async_GetRows(uv_work_t *req)
 
   try
   {
-    if (!ebaton->noMetadata) {
+    if ( ebaton->metaData ) {
         Connection::CopyMetaData ( ebaton->columnNames, ebaton->fields, njsRS->meta_,
                                    njsRS->numCols_ );
     }

--- a/src/njs/src/njsResultSet.cpp
+++ b/src/njs/src/njsResultSet.cpp
@@ -201,11 +201,11 @@ NAN_GETTER(ResultSet::GetMetaData)
     return;
   }
   std::string *columnNames = new std::string[njsResultSet->numCols_];
-  Connection::CopyMetaData ( columnNames, njsResultSet->meta_,
-                             njsResultSet->numCols_ );
+  FieldInfo *fields = new FieldInfo[njsResultSet->numCols_];
+  Connection::CopyMetaData ( columnNames, fields, njsResultSet->meta_, njsResultSet->numCols_ );
+
   Local<Value> meta;
-  meta = Connection::GetMetaData( columnNames,
-                                  njsResultSet->numCols_ );
+  meta = Connection::GetMetaData( fields, njsResultSet->numCols_ );
   info.GetReturnValue().Set(meta);
 }
 
@@ -430,7 +430,7 @@ void ResultSet::Async_GetRows(uv_work_t *req)
 
   try
   {
-    Connection::CopyMetaData ( ebaton->columnNames, njsRS->meta_,
+    Connection::CopyMetaData ( ebaton->columnNames, ebaton->fields, njsRS->meta_,
                                njsRS->numCols_ );
     ebaton->numCols      = njsRS->numCols_;
     if( !njsRS->defineBuffers_ ||

--- a/src/njs/src/njsResultSet.cpp
+++ b/src/njs/src/njsResultSet.cpp
@@ -200,6 +200,7 @@ NAN_GETTER(ResultSet::GetMetaData)
     info.GetReturnValue().SetUndefined();
     return;
   }
+
   std::string *columnNames = new std::string[njsResultSet->numCols_];
   FieldInfo *fields = new FieldInfo[njsResultSet->numCols_];
   Connection::CopyMetaData ( columnNames, fields, njsResultSet->meta_, njsResultSet->numCols_ );
@@ -430,8 +431,10 @@ void ResultSet::Async_GetRows(uv_work_t *req)
 
   try
   {
-    Connection::CopyMetaData ( ebaton->columnNames, ebaton->fields, njsRS->meta_,
-                               njsRS->numCols_ );
+    if (!ebaton->noMetadata) {
+        Connection::CopyMetaData ( ebaton->columnNames, ebaton->fields, njsRS->meta_,
+                                   njsRS->numCols_ );
+    }
     ebaton->numCols      = njsRS->numCols_;
     if( !njsRS->defineBuffers_ ||
         njsRS->fetchRowCount_  < getRowsBaton->numRows )

--- a/src/njs/src/njsUtils.h
+++ b/src/njs/src/njsUtils.h
@@ -58,6 +58,42 @@
 
 #include "njsMessages.h"
 
+// Original oracle db data types.
+typedef enum
+{
+  DBTYPE_UNKNOWN           = 0,
+  DBTYPE_VARCHAR           = 1001,
+  DBTYPE_NUMBER            = 1002,
+  DBTYPE_INTEGER           = 1003,
+  DBTYPE_DOUBLE            = 1004,
+  DBTYPE_STRING            = 1005,
+  DBTYPE_LONG              = 1008,
+  DBTYPE_DATE              = 1012,
+  DBTYPE_RAW               = 1023,
+  DBTYPE_LONGRAW           = 1024,
+  DBTYPE_UNSIGNEDINTEGER   = 1068,
+  DBTYPE_ROWID             = 1104,
+  DBTYPE_FIXEDCHAR         = 1096,
+  DBTYPE_BINARYFLOAT       = 1100,
+  DBTYPE_BINARYDOUBLE      = 1101,
+  DBTYPE_UDT               = 1108,
+  DBTYPE_REF               = 1111,
+  DBTYPE_CLOB              = 1112,
+  DBTYPE_BLOB              = 1113,
+  DBTYPE_BFILE             = 1114,
+  DBTYPE_RSET              = 1116,
+  DBTYPE_YEARMONTH         = 1182,
+  DBTYPE_DAYSECOND         = 1183,
+  DBTYPE_TIMESTAMP         = 1187,
+  DBTYPE_TIMESTAMPTZ       = 1188,
+  DBTYPE_UROWID            = 1208,
+  DBTYPE_TIMESTAMPLTZ      = 1232,
+  DBTYPE_TYPEBASE          = 1999,
+  DBTYPE_DATETIMEARRAY     = 1998,
+  DBTYPE_INTERVALARRAY     = 1997
+}DbDataType;
+
+
 // User specified data types for binds and defines.
 typedef enum
 {


### PR DESCRIPTION
# extend metaData  items

`metaData` array now exposes items with more properties:

- `name` : field name
- `type` : field data type (JS datatype)
- `originalType` : field data type (DB datatype)
- `size` : DB field size
- `precision` : DB field precision
- `scale` : DB field scale
- `isNullable` : field can be null


```javascript
connection.execute(
  "... SQL statement ...",
  [],
  function(err, result)
  {
    var columns = _.map(result.metaData, function(c)
    {
      return {
        name: c.name || '',
        type: c.type || '',
        originalType: c.originalType || 'undefined',
        size: c.size || 0,
        precision: c.precision || 0,
        scale: c.scale || 0,
        isNullable: c.isNullable
      };
    });
  });
```
Signed-off-by: Leonardo Olmi [leo.olmi@gmail.com](mailto:leo.olmi@gmail.com)