### PR TITLE
Make API compatible with Promises

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -18,13 +18,15 @@
  *****************************************************************************/
 
 var resultset = require('./resultset.js');
+var deferred = require('./deferred.js');
 
 // This execute function is used to override the execute method of the Connection
 // class, which is defined in the C layer. The override allows us to do things
 // like extend out the resultSet instance prior to passing it to the caller.
-function execute(a1, a2, a3, a4) {
+function execute(a1, a2, a3) {
+  var args = deferred.variadic(arguments);
   var self = this;
-  var executeCb;
+  var executeCb = args.callback;
   var custExecuteCb;
 
   // Added this check so that node doesn't hang if no arguments are passed.
@@ -50,34 +52,39 @@ function execute(a1, a2, a3, a4) {
     executeCb(null, result);
   };
 
-  switch (arguments.length) {
+  var length = typeof arguments[arguments.length - 1] == 'function' ? arguments.length : arguments.length + 1;
+  switch (length) {
     case 4:
-      executeCb = a4;
-      self._execute.call(self, a1, a2, a3, custExecuteCb);
+      self._execute(a1, a2, a3, custExecuteCb);
       break;
     case 3:
-      executeCb = a3;
-      self._execute.call(self, a1, a2, custExecuteCb);
+      self._execute(a1, a2, custExecuteCb);
       break;
     case 2:
-      executeCb = a2;
-      self._execute.call(self, a1, custExecuteCb);
+      self._execute(a1, custExecuteCb);
       break;
   }
+
+  return executeCb.promise;
 }
 
 // This commit function is just a place holder to allow for easier extension later.
 function commit() {
   var self = this;
+  var args = deferred.variadic(arguments);
 
-  self._commit.apply(self, arguments);
+  self._commit.apply(self, args);
+
+  return args.promise;
 }
 
 // This rollback function is just a place holder to allow for easier extension later.
 function rollback() {
   var self = this;
+  var args = deferred.variadic(arguments);
 
-  self._rollback.apply(self, arguments);
+  self._rollback.apply(self, args);
+  return args.promise;
 }
 
 // This release function is used to override the release method of the Connection
@@ -86,6 +93,7 @@ function rollback() {
 // method so the pool can dequeue the next connection request.
 function release(releaseCb) {
   var self = this;
+  releaseCb = deferred(releaseCb);
 
   // _pool will only exist on connections obtained from a pool.
   if (self._pool && self._pool.queueRequests !== false) {
@@ -97,14 +105,19 @@ function release(releaseCb) {
   } else {
     self._release(releaseCb);
   }
+
+  return releaseCb.promise;
 }
 
 // This release function is just a place holder to allow for easier extension later.
 // It's attached to the module as break is a reserved word.
 module.break = function() {
   var self = this;
+  var args = deferred.variadic(arguments);
 
-  self._break.apply(self, arguments);
+  self._break.apply(self, args);
+
+  return args.promise;
 };
 
 // The extend method is used to extend the Connection instance from the C layer with

--- a/lib/deferred.js
+++ b/lib/deferred.js
@@ -1,0 +1,61 @@
+//
+// First check to see if the Promise class is defined:
+//
+if (typeof Promise == 'undefined') {
+	module.Promise = function() {
+		function err() {
+			throw new Error('This version of the Node.js runtime does not support promises');
+		}
+		this.then = this.catch = err;
+	};
+} else {
+	// use native Promise implementation
+	module.Promise = Promise;
+}
+
+function deferred(cb) {
+	if (typeof cb != 'function')
+		cb = function noop() { };
+
+	var yes, no;
+	var promise = new module.Promise(function (_y, _n) {
+		yes = _y;
+		no = _n;
+	});
+
+	function newCb(err) {
+		var rest = [].slice.call(arguments, 1);
+		cb.apply(null, arguments);
+		if (err)
+			return no(err);
+		yes.apply(null, rest);
+	}
+	newCb.promise = promise;
+
+	return newCb;
+}
+
+deferred.variadic = function (args) {
+	args = [].slice.call(args, []);
+	var callback = deferred();
+
+	// console.log(arguments.callee.caller.name, '(', args, ')')
+
+	if (args.length == 0)
+		args.push(callback);
+
+	if (typeof args[args.length - 1] == 'function') {
+		// if the last is already a callback, then wrap it:
+		callback = deferred(args[args.length - 1]);
+		args[args.length - 1] = callback;
+	} else {
+		// otherwise make sure the last arg is a callback:
+		args.push(callback);
+	}
+
+	args.promise = callback.promise;
+	args.callback = callback;
+	return args;
+};
+
+module.exports = deferred;

--- a/lib/lob.js
+++ b/lib/lob.js
@@ -19,6 +19,7 @@
 
 var Duplex = require('stream').Duplex;
 var util = require('util');
+var deferred = require('./deferred.js');
 
 util.inherits(Lob, Duplex);
 
@@ -88,6 +89,7 @@ Lob.prototype._read = function() {
 
 Lob.prototype._write = function(data, encoding, cb) {
   var self = this;
+  cb = deferred(cb);
 
   self.iLob.write(
     data,
@@ -100,10 +102,13 @@ Lob.prototype._write = function(data, encoding, cb) {
       cb();
     }
   );
+
+  return cb.promise;
 };
 
 Lob.prototype.close = function(cb) {
   var self = this;
+  cb = deferred(cb);
 
   if (cb) {
     this.once('close', cb);
@@ -119,6 +124,8 @@ Lob.prototype.close = function(cb) {
 
     self.iLob = null;
   }
+
+  return cb.promise;
 };
 
 module.exports.Lob = Lob;

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -22,9 +22,10 @@ var oracledbInst;
 var Lob = require('./lob.js').Lob;
 var pool = require('./pool.js');
 var connection = require('./connection.js');
+var deferred = require('./deferred.js');
 
 try {
-  oracledbCLib =  require('../build/Release/oracledb');
+  oracledbCLib = require('../build/Release/oracledb');
 } catch (err) {
   if (err.code === 'MODULE_NOT_FOUND') {
     oracledbCLib = require('../build/Debug/oracledb');
@@ -42,6 +43,7 @@ oracledbCLib.Oracledb.prototype.newLob = function(iLob) {
 // things like extend out the pool instance prior to passing it to the caller.
 function createPool(poolAttrs, createPoolCb) {
   var self = this;
+  createPoolCb = deferred(createPoolCb);
 
   self._createPool(poolAttrs, function(err, poolInst) {
     if (err) {
@@ -53,6 +55,8 @@ function createPool(poolAttrs, createPoolCb) {
 
     createPoolCb(undefined, poolInst);
   });
+
+  return createPoolCb.promise;
 }
 
 // This getConnection function is used the override the getConnection method of the
@@ -60,6 +64,7 @@ function createPool(poolAttrs, createPoolCb) {
 // things like extend out the connection instance prior to passing it to the caller.
 function getConnection(connAttrs, createConnectionCb) {
   var self = this;
+  createConnectionCb = deferred(createConnectionCb);
 
   self._getConnection(connAttrs, function(err, connInst) {
     if (err) {
@@ -71,6 +76,8 @@ function getConnection(connAttrs, createConnectionCb) {
 
     createConnectionCb(undefined, connInst);
   });
+
+  return createConnectionCb.promise;
 }
 
 // The extend method is used to extend the Oracledb instance from the C layer with

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -18,12 +18,14 @@
  *****************************************************************************/
 
 var connection = require('./connection.js');
+var deferred = require('./deferred.js');
 
 // completeConnectionRequest does the actual work of getting a connection from a
 // pool when queuing is enabled. It's abstracted out so it can be called from
 // getConnection and checkRequestQueue constently.
 function completeConnectionRequest(getConnectionCb) {
   var self = this;
+  getConnectionCb = deferred(getConnectionCb);
 
   // Incrementing _connectionsOut prior to making the async call to get a connection
   // to prevent other connection requests from exceeding the poolMax.
@@ -52,6 +54,8 @@ function completeConnectionRequest(getConnectionCb) {
 
     getConnectionCb(undefined, connInst);
   });
+
+  return getConnectionCb.promise;
 }
 
 // Requests for connections from pools are queued by default (can be overridden
@@ -133,13 +137,14 @@ function getConnection(getConnectionCb) {
   var payload;
   var timeoutHandle;
   var timerIdx;
+  getConnectionCb = deferred(getConnectionCb);
 
   // Added this check because if the pool isn't valid and we reference self.poolMax
   // (which is a C layer getter) an error will be thrown.
   if (!self._isValid) {
     if (getConnectionCb && typeof getConnectionCb === 'function') {
       getConnectionCb(new Error('NJS-002: invalid pool'));
-      return;
+      return getConnectionCb.promise;
     } else {
       throw new Error('NJS-002: invalid pool');
     }
@@ -157,7 +162,7 @@ function getConnection(getConnectionCb) {
 
           getConnectionCb(err);
 
-          return;
+          return getConnectionCb.promise;
         }
 
         getConnectionCb(null, connInst);
@@ -198,11 +203,14 @@ function getConnection(getConnectionCb) {
       self._maxQueueLength = Math.max(self._maxQueueLength, self._connRequestQueue.length);
     }
   }
+
+  return getConnectionCb.promise;
 }
 
 
 function terminate(terminateCb) {
   var self = this;
+  terminateCb = deferred(terminateCb);
 
   self._terminate(function(err) {
     if (!err) {
@@ -211,6 +219,8 @@ function terminate(terminateCb) {
 
     terminateCb(err);
   });
+
+  return terminateCb.promise;
 }
 
 // logStats is used to add a hidden method (_logStats) to each pool instance. This
@@ -220,7 +230,7 @@ function terminate(terminateCb) {
 function logStats() {
   var self = this;
   var averageTimeInQueue;
-  
+
   if (!self._isValid) {
     console.log('_logStats must be called prior to terminating pool.');
     return;

--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -17,25 +17,33 @@
  *
  *****************************************************************************/
 
+var deferred = require('./deferred.js');
+
 // This close function is just a place holder to allow for easier extension later.
 function close() {
   var self = this;
+  var args = deferred.variadic(arguments);
 
-  self._close.apply(self, arguments);
+  self._close.apply(self, args);
+  return args.promise;
 }
 
 // This getRow function is just a place holder to allow for easier extension later.
 function getRow() {
   var self = this;
+  var args = deferred.variadic(arguments);
 
-  self._getRow.apply(self, arguments);
+  self._getRow.apply(self, args);
+  return args.promise;
 }
 
 // This getRows function is just a place holder to allow for easier extension later.
 function getRows() {
   var self = this;
+  var args = deferred.variadic(arguments);
 
-  self._getRows.apply(self, arguments);
+  self._getRows.apply(self, args);
+  return args.promise;
 }
 
 // The extend method is used to extend the ResultSet instance from the C layer with


### PR DESCRIPTION
I am opening this pull request for discussion.  Theoretically, this does not break the current API, but extends it to return a Promise _and_ also call an (optionally) provided node-style callback.

## Concept

The concept is to convert a method of the form:

```js
function someAsyncFunction(callback) {
    // ... do async work, and at some point later do:
    callback(err, result);
}
```

...and converted to support both Promises _and_ callbacks:

```js
function someAsyncFunction(callback) {
    // make a callback that wraps the passed one that automatically resolves/rejects an internal promise
    callback = deferred(callback);

    // ... do async work, and at some point later do:
    callback(err, result);

    // return the promise that gets resolved by a line similar to the one above:
    return callback.promise;
}
```

## Extended Oracle API

What the commit contained in this pull request allows for is a backward compatible node-style callback API, while supporting promises.  This means that this is still valid code:

```js
oracle.getConnection(CONFIG, (err, conn) => {
	conn.execute('SELECT * FROM MY_TABLE WHERE ROWNUM < 5', { }, { resultSet: true }, (err, res) => {
		res.resultSet.getRow((err, row) => {
			console.log(row)
		})
	})
})
```

But more interestingly, the API methods also return promises, which means that when using a version of Node.js that supports generators, and also utilizing the Node module `co` (that allows generators to support promises), this code can now be written:

```js
co(function * () {
	try {
		const conn = yield oracle.getConnection(CONFIG)
		const res = yield conn.execute('SELECT * FROM CSUD_PCI WHERE ROWNUM < 5', { }, { resultSet: true })

		let row = null
		while (row = yield res.resultSet.getRow()) {
			console.log(row)
		}
		yield res.resultSet.close()
		yield conn.release()
	} catch (e) {
		// handle error and cleanup resources
	}
})
```