### PR TITLE
Better error msg when Instant Client is missing

### DIFF
--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -48,7 +48,7 @@ try {
     fileMatch = function(dir, match){
       try {
         return fs.readdirSync(dir).some(function(file){
-          if(file.indexOf(match)>=0) {console.log(dir +'/'  +file);return true;}
+          if(file.substr(0, searchString.length) === searchString) {return true;}
         });
       }
       catch (err) {

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -25,7 +25,6 @@ var connection = require('./connection.js');
 var path;
 var fs;
 var fileExists;
-var fileMatch;
 
 try {
   oracledbCLib =  require('../build/Release/oracledb');
@@ -45,21 +44,10 @@ try {
       }
     };
     
-    fileMatch = function(dir, searchString){
-      try {
-        return fs.readdirSync(dir).some(function(file){
-          if(file.substr(0, searchString.length) === searchString) {return true;}
-        });
-      }
-      catch (err) {
-          return false;
-      }
-    };
-    
     process.env.PATH.split(path.delimiter).forEach(function(dir) {
       var msg = function(){
         console.log();
-        console.log('**** Found Oracle Instant Client in PATH in the following directory: ' + dir);
+        console.log('**** Found an Oracle client library in PATH in the following directory: ' + dir);
         console.log('**** But the version is either corrupt or not for the same OS and/or Node.js processor architecture in which you\'re running on.');
         console.log('**** Your Node.js processor architecture is ' + process.arch + '.');
         console.log('**** If you have multiple Instant Client folders defined in PATH, only the first one is loaded.');
@@ -68,13 +56,14 @@ try {
         throw err;
       };
       
-      if(fileExists(path.join(dir, 'oci.dll')) || fileMatch(dir, 'libclntsh.')) {msg();}
+      if(fileExists(path.join(dir, 'oci.dll'))) {msg();}
       
     });
     
     console.log();
-    console.log('**** Oracle Instant Client directory was not found.');
-    console.log('**** Add the Instant Client directory to your PATH environment variable, then try again.');
+    console.log('****');
+    console.log('**** AN ORACLE CLIENT LIBRARY WAS NOT FOUND.');
+    console.log('****');
     console.log();
     throw err;
   }

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -23,7 +23,9 @@ var Lob = require('./lob.js').Lob;
 var pool = require('./pool.js');
 var connection = require('./connection.js');
 var path;
-var existsSync;
+var fs;
+var fileExists;
+var fileMatch;
 
 try {
   oracledbCLib =  require('../build/Release/oracledb');
@@ -31,22 +33,47 @@ try {
   if (err.code === 'MODULE_NOT_FOUND') {
     oracledbCLib = require('../build/Debug/oracledb');
   } else {
-    
     path = require('path');
-    existsSync = require('fs').existsSync || require('path').existsSync;
+    fs = require('fs');
+    
+    fileExists = function(fullPathToFile) {
+      try {
+          return fs.statSync(fullPathToFile).isFile();
+      }
+      catch (err) {
+          return false;
+      }
+    };
+    
+    fileMatch = function(dir, match){
+      try {
+        return fs.readdirSync(dir).some(function(file){
+          if(file.indexOf(match)>=0) {console.log(dir +'/'  +file);return true;}
+        });
+      }
+      catch (err) {
+          return false;
+      }
+    };
     
     process.env.PATH.split(path.delimiter).forEach(function(dir) {
-      if(existsSync(path.join(dir, 'oci.dll'))) {
-		  console.log();
-		  console.log('**** Found Oracle Instant Client in PATH in the following direcory:' + dir);
-		  console.log('**** Make sure the version you have installed is the correct one.');
-		  console.log('**** Needs to match your the bitness (32bit/64bit) of your Node.js and be for the Operating System that you are using.');
-		  console.log();
-		  throw err;
-		}
+      var msg = function(){
+        console.log();
+        console.log('**** Found Oracle Instant Client in PATH in the following directory: ' + dir);
+        console.log('**** But the version is either corrupt or not for the same OS and/or Node.js processor architecture in which you\'re running on.');
+        console.log('**** Your Node.js processor architecture is ' + process.arch + '.');
+        console.log('**** If you have multiple Instant Client folders defined in PATH, only the first one is loaded.');
+        console.log('**** Therefore, the first to appear needs to be correct one.');
+        console.log();
+        throw err;
+      };
+      
+      if(fileExists(path.join(dir, 'oci.dll')) || fileMatch(dir, 'libclntsh.')) {msg();}
+      
     });
+    
     console.log();
-    console.log('**** Oracle Instant Client directory not found.');
+    console.log('**** Oracle Instant Client directory was not found.');
     console.log('**** Add the Instant Client directory to your PATH environment variable, then try again.');
     console.log();
     throw err;

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -22,6 +22,8 @@ var oracledbInst;
 var Lob = require('./lob.js').Lob;
 var pool = require('./pool.js');
 var connection = require('./connection.js');
+var path;
+var existsSync;
 
 try {
   oracledbCLib =  require('../build/Release/oracledb');
@@ -29,6 +31,24 @@ try {
   if (err.code === 'MODULE_NOT_FOUND') {
     oracledbCLib = require('../build/Debug/oracledb');
   } else {
+	
+	existsSync = require('fs').existsSync || require('path').existsSync;
+	ic_found = false;
+	
+    process.env.PATH.split(path.delimiter).forEach(function(dir) {
+      if(existsSync(path.join(dir, 'oci.dll'))) {
+		  console.log();
+		  console.log('**** Found Oracle Instant Client in PATH in the following direcory:' + dir);
+		  console.log('**** Make sure the version you have installed is the correct one.');
+		  console.log('**** Needs to match your the bitness (32bit/64bit) of your Node.js and be for the Operating System that you are using.');
+		  console.log();
+		  throw err;
+		}
+    });
+    console.log();
+    console.log('**** Oracle Instant Client directory not found.');
+    console.log('**** Add the Instant Client directory to your PATH environment variable, then try again.');
+    console.log();
     throw err;
   }
 }

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -50,7 +50,7 @@ try {
         console.log('**** Found an Oracle client library in PATH in the following directory: ' + dir);
         console.log('**** But the version is either corrupt or not for the same OS and/or Node.js processor architecture in which you\'re running on.');
         console.log('**** Your Node.js processor architecture is ' + process.arch + '.');
-        console.log('**** If you have multiple Instant Client folders defined in PATH, only the first one is loaded.');
+        console.log('**** If you have multiple Oracle client directories defined in PATH, only the first one is loaded.');
         console.log('**** Therefore, the first to appear needs to be correct one.');
         console.log();
         throw err;

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -32,6 +32,7 @@ try {
     oracledbCLib = require('../build/Debug/oracledb');
   } else {
     
+    path = require('path');
     existsSync = require('fs').existsSync || require('path').existsSync;
     
     process.env.PATH.split(path.delimiter).forEach(function(dir) {

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -31,10 +31,9 @@ try {
   if (err.code === 'MODULE_NOT_FOUND') {
     oracledbCLib = require('../build/Debug/oracledb');
   } else {
-	
-	existsSync = require('fs').existsSync || require('path').existsSync;
-	ic_found = false;
-	
+    
+    existsSync = require('fs').existsSync || require('path').existsSync;
+    
     process.env.PATH.split(path.delimiter).forEach(function(dir) {
       if(existsSync(path.join(dir, 'oci.dll'))) {
 		  console.log();

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -45,7 +45,7 @@ try {
       }
     };
     
-    fileMatch = function(dir, match){
+    fileMatch = function(dir, searchString){
       try {
         return fs.readdirSync(dir).some(function(file){
           if(file.substr(0, searchString.length) === searchString) {return true;}


### PR DESCRIPTION
If there is a pending error and Instant Client is not found in PATH then an error message is displayed prior to `throw err;`.

Otherwise, if it is found in PATH then the directory it is **first** found in is outputed with a message asking the user to check that the correct version is installed.

Signed-off-by: Bill Christo billchristo@gmail.com
