### PR TITLE
unused _connRequestTimersMap property keep growing will cause memory  leak

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -82,7 +82,7 @@ function checkRequestQueue() {
   if (self._usingQueueTimeout) {
     clearTimeout(payload.timeoutHandle);
 
-    self._connRequestTimersMap[payload.timerIdx] = null;
+    delete self._connRequestTimersMap[payload.timerIdx];
     payload.timeoutHandle = null;
     payload.timerIdx = null;
   }
@@ -117,8 +117,7 @@ function onRequestTimeout(timerIdx) {
     requestIndex = self._connRequestQueue.indexOf(payloadToDequeue);
 
     self._connRequestQueue.splice(requestIndex, 1);
-    self._connRequestTimersMap[timerIdx] = null;
-
+    delete self._connRequestTimersMap[timerIdx];
     payloadToDequeue.getConnectionCb(new Error('NJS-040: connection request timeout'));
   }
 }


### PR DESCRIPTION
delete unused _connRequestTimersMap property to avoid memory leak

Signed-off-by: David Yao  welcometoyzw@163.com