### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -447,7 +447,7 @@ the steps in [5.3.1](#instosxICuser) instead.
 
 Download the free **Basic** and **SDK** ZIPs from
 [Oracle Technology Network](http://www.oracle.com/technetwork/topics/intel-macsoft-096467.html)
-and install them into the same directory:
+and install them into the same directory  (don't use 'Basic-Lite', it won't work) :
 
 ```
 sudo su -


### PR DESCRIPTION
I ran into an issue getting this installed.  I mistakenly used Basic-Lite because I was cheap w/ my disk space.   And description on Oracle Install site led me to believe it would work:  ("Basic Lite: Smaller version of the Basic, with only English error messages and Unicode, ASCII, and Western European character set support")

Changing the install script to specifically point out not to use Basic Lite because it segfaults.    The description at the Oracle Instant Client leads one to believe that they're compatible.