### PR TITLE
Use true-case-path to fix re-entrancy issue on Windows and Webpack

### DIFF
--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -39,7 +39,13 @@ var binaryDebugPath = '../build/Debug/oracledb.node';
 // --debug oracledb' was used.  Typically only the maintainers of
 // node-oracledb do this.
 try {
-  oracledbCLib =  require(binaryReleasePath);
+  if (process.platform === 'win32') {
+    var trueCasePath = require('true-case-path');
+    oracledbCLibRequire = trueCasePath(binaryReleasePath) || binaryReleasePath;
+    oracledbCLib = require(oracledbCLibRequire);
+  } else {
+    oracledbCLib = require(binaryReleasePath);
+  }
 } catch (err) {
   var nodeInfo = process.versions.node + ' (' + process.platform + ', ' + process.arch +')\n';
   var fullReleasePath = require('path').resolve(__dirname, binaryReleasePath);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "url": "git://github.com/oracle/node-oracledb.git"
   },
   "dependencies": {
-    "nan": "~2.8.0"
+    "nan": "~2.8.0",
+    "true-case-path": "^1.0.2"
   },
   "devDependencies": {
     "mocha": "^2.4.5",


### PR DESCRIPTION
This issue is a fix for https://github.com/oracle/node-oracledb/issues/818. This issue is similar to https://github.com/sass/node-sass/pull/2149, which


> When using node-sass through multiple entry points (as can happen when using webpack) on Windows, the casing of the drive letter in the path can be inconsistent. Since Node is case-sensitive to a fault, this results in Node attempting to create a second instance of the native binding, which results in a Module did not self-register error.
>
> The fix is to use true-case-path to normalize the binding path, to prevent unintended duplicate bindings from occurring.