### PR TITLE
added mirror options for working behine firewalls via a releases mirror.

### DIFF
--- a/package/oracledbinstall.js
+++ b/package/oracledbinstall.js
@@ -51,9 +51,15 @@ try {
   return;
 }
 
+// Note: if you are behine a corporate firewall, and your proxy blocks github releases, 
+// please use the mirror option, by passing in an environment variable denoting your 
+// internal mirror host.
+const { GITHUB_MIRROR, POST_INSTALL_MIRROR, NEXUS_MIRROR, ARTIFACTORY_MIRROR, RELEASES_MIRROR } = process.env;
+const mirror = GITHUB_MIRROR || POST_INSTALL_MIRROR || NEXUS_MIRROR || ARTIFACTORY_MIRROR || RELEASES_MIRROR;
+
 // Note: the Makefile uses these hostname and path values for the npm
 // package but will substitute them for the staging package
-const PACKAGE_HOSTNAME = 'github.com';
+const PACKAGE_HOSTNAME = mirror || 'github.com';
 const PACKAGE_PATH_REMOTE = '/oracle/node-oracledb/releases/download/' + packageUtil.dynamicProps.GITHUB_TAG + '/' + packageUtil.dynamicProps.PACKAGE_FILE_NAME;
 const SHA_PATH_REMOTE = '/oracle/node-oracledb/releases/download/' + packageUtil.dynamicProps.GITHUB_TAG + '/' + packageUtil.SHA_FILE_NAME;
 const PORT = 443;


### PR DESCRIPTION
Here at Florida Blue we are behind a fairly restrictive firewall. Due to this, we have to have a facility for mirrors, especially where post install scripts are hard coded to look for releases on github, or other. The oracledb node driver is an example of this, as is electronjs. Both have post install scripts that gather information about the target machine's architecture and then attempt to download the related dependencies from github. Unfortunately, our firewall policies err on the side of caution. My proposed changes, add multiple mirror options, passed in as Environment Variables, in the same style as the Proxy Allowance that is already in place.

Signed-off-by: Sean Willison <sean.willison@bcbsfl.com>

