### PR TITLE
WIP: 836 - `pool.close()` should iterate open connections and close them

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -209,10 +209,10 @@ function close(a1, a2) {
   nodbUtil.assert(arguments.length !== 1 && arguments.length !== 2, 'NJS-009');  
   nodbUtil.assert(typeof closeCallback === 'function', 'NJS-006', 1);
 
-  const closeMode = arguments.length === 1 ? 'DPI_MODE_POOL_CLOSE_DEFAULT' : 'DPI_MODE_POOL_CLOSE_FORCE';
+  const forceClose = arguments.length === 1 ? false : arguments[arguments.length - 2];
 
   if(arguments.length === 1) {
-    closePool(closeMode,closeCallback);
+    closePool(forceClose,closeCallback);
   }else {
 
     //If a drainTime has been provided, it will use that value, given that connections count is not 0
@@ -227,20 +227,20 @@ function close(a1, a2) {
     nodbUtil.assert(drainTime >= 1 && drainTime <= upperLimitTimeout, 'NJS-005', 2);
 
     if(drainTime === 0 ) {
-      closePool(closeMode,closeCallback);
+      closePool(forceClose,closeCallback);
     }else {
       setTimeout(() => {
-        closePool(closeMode,closeCallback);
+        closePool(forceClose,closeCallback);
       }, drainTime);
     }    
   }
 }
 
-function closePool(closeMode, closeCallback) {
+function closePool(forceClose, closeCallback) {
   let self = this;
   self.closing = true;
 
-  self._close(closeMode, (err) => {
+  self._close(forceClose, (err) => {
     if (!err) {
       self._isValid = false;
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -201,55 +201,52 @@ function getConnection(a1, a2) {
 
 getConnectionPromisified = nodbUtil.promisify(getConnection);
 
-
-function close(a1, a2) {
+function closeWrapper(mode, closeCb) {
   var self = this;
-  const closeCallback = arguments[arguments.length - 1];
 
-  nodbUtil.assert(arguments.length !== 1 && arguments.length !== 2, 'NJS-009');  
-  nodbUtil.assert(typeof closeCallback === 'function', 'NJS-006', 1);
-
-  const forceClose = arguments.length === 1 ? false : arguments[arguments.length - 2];
-
-  if(arguments.length === 1) {
-    closePool(forceClose,closeCallback);
-  }else {
-
-    //If a drainTime has been provided, it will use that value, given that connections count is not 0
-    //if connectionsOut is === 0, closePool is called right away, as there is no need to wait at all.
-    const drainTime = self._connectionsOut === 0 ? 0 : arguments[arguments.length - 2] * 1000;
-
-    //SetTimeout does not accept numbers greather than a 32bit signed integer.
-    const upperLimitTimeout = 2147483647;
-    
-    //test for drainTime being a number and test the 32 bit max value
-    nodbUtil.assert(typeof drainTime === 'number', 'NJS-006', 2);
-    nodbUtil.assert(drainTime >= 1 && drainTime <= upperLimitTimeout, 'NJS-005', 2);
-
-    if(drainTime === 0 ) {
-      closePool(forceClose,closeCallback);
-    }else {
-      setTimeout(() => {
-        closePool(forceClose,closeCallback);
-      }, drainTime);
-    }    
-  }
-}
-
-function closePool(forceClose, closeCallback) {
-  let self = this;
-  self.closing = true;
-
-  self._close(forceClose, (err) => {
+  // mode flag needs to be passed on to cpp
+  self._close(function (err) {
     if (!err) {
       self._isValid = false;
 
       self.emit('_after_close', self);
     }
-    closeCallback(err);
+    closeCb(err);
   });
 }
 
+function close(a1, a2) {
+  var self = this;
+
+  nodbUtil.assert(arguments.length === 1 || arguments.length === 2, 'NJS-009');
+
+  const closeCb = arguments[arguments.length - 1];
+  nodbUtil.assert(typeof closeCb === 'function', 'NJS-006', 1);
+
+  const forceClose = arguments.length === 1 ? false : true;
+  self.closing = forceClose;
+
+  if (arguments.length === 1) {
+    self.closeWrapper(false, closeCb);
+  } else {
+    //If a drainTime has been provided, it will use that value, given that connections count is not 0
+    //if connectionsOut is === 0, closePool is called right away, as there is no need to wait at all.
+    const drainTime = self._connectionsOut === 0 ? 0 : arguments[arguments.length - 2] * 1000;
+    //SetTimeout does not accept numbers greather than a 32bit signed integer.
+    const upperLimitTimeout = 2147483647;
+
+    nodbUtil.assert(typeof drainTime === 'number', 'NJS-006', 2);
+    nodbUtil.assert(drainTime >= 1 && drainTime <= upperLimitTimeout, 'NJS-005', 2);
+
+    if (drainTime === 0) {
+      self.closeWrapper(true, closeCb);
+    } else {
+      setTimeout(() => {
+        self.closeWrapper(true, closeCb);
+      }, drainTime);
+    }
+  }
+}
 
 closePromisified = nodbUtil.promisify(close);
 
@@ -433,12 +430,12 @@ function extend(pool, poolAttrs, poolAlias, oracledb) {
         writable: true
       },
       closing: {
-        get: function() {
-          return closing;
-        },
-        enumerable: true,        
-        value: false,
-        writable: false
+        writable: true,
+        enumerable: true,
+        value: false
+      },
+      closeWrapper: {
+        value: closeWrapper
       }
     }
   );

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -139,8 +139,11 @@ function getConnection(a1, a2) {
 
   nodbUtil.assert(arguments.length >= 1 && arguments.length <= 2, 'NJS-009');
   nodbUtil.assert(typeof getConnectionCb === 'function', 'NJS-006', arguments.length);
-  nodbUtil.assert(self.closing === false, 'NJS-064', self.poolAlias);
 
+  if (self.closing === true) {
+     getConnectionCb(new Error(nodbUtil.getErrorMessage('NJS-064', self.poolAlias)));
+     return;
+  }
 
   // Optional JSON parameter
   if (arguments.length > 1 ) {
@@ -216,28 +219,36 @@ function closeWrapper(mode, closeCb) {
 
 function close(a1, a2) {
   var self = this;
+  var drainTime;
+  var closeCb;
 
+  //asserts whether there are 1 or 2 arguments, throws error in case this fails
   nodbUtil.assert(arguments.length === 1 || arguments.length === 2, 'NJS-009');
 
-  const closeCb = arguments[arguments.length - 1];
-  nodbUtil.assert(typeof closeCb === 'function', 'NJS-006', 1);
+  switch (arguments.length) {
+    case 1:
+      nodbUtil.assert(typeof a1 === 'function', 'NJS-006', 1);
+      closeCb = a1;
+      break;
+    case 2:
+      nodbUtil.assert(typeof a1 === 'number', 'NJS-006', 1);
+      nodbUtil.assert(typeof a2 === 'function', 'NJS-006', 2);      
+      closeCb = a2;
 
-  const forceClose = arguments.length === 1 ? false : true;
-  self.closing = forceClose;
+      //if connectionsOut is === 0, closePool is called right away, as there is no need to wait at all.
+      drainTime = self._connectionsOut === 0 ? 0 : a1 * 1000;  // a1 represents seconds of time
+
+      // SetTimeout does not accept numbers greater than a 32-bit signed integer.
+      const upperLimitTimeout = 2147483647;
+      nodbUtil.assert(drainTime >= 0 && drainTime <= upperLimitTimeout, 'NJS-005', 1);
+      break;
+  }
 
   if (arguments.length === 1) {
+    self.closing = false;
     self.closeWrapper(false, closeCb);
   } else {
-    
-    //If a drainTime has been provided, it will use that value, given that connections count is not 0
-    //if connectionsOut is === 0, closePool is called right away, as there is no need to wait at all.
-    const drainTime = self._connectionsOut === 0 ? 0 : arguments[arguments.length - 2] * 1000;
-    //SetTimeout does not accept numbers greather than a 32bit signed integer.
-    const upperLimitTimeout = 2147483647;
-
-    nodbUtil.assert(typeof drainTime === 'number', 'NJS-006', 2);
-    nodbUtil.assert(drainTime >= 0 && drainTime <= upperLimitTimeout, 'NJS-005', 2);
-
+    self.closing = true;
     if (drainTime === 0) {
       self.closeWrapper(true, closeCb);
     } else {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -141,6 +141,7 @@ function getConnection(a1, a2) {
   nodbUtil.assert(typeof getConnectionCb === 'function', 'NJS-006', arguments.length);
   nodbUtil.assert(self.closing === false, 'NJS-064', self.poolAlias);
 
+
   // Optional JSON parameter
   if (arguments.length > 1 ) {
     options = arguments[0];
@@ -203,9 +204,8 @@ getConnectionPromisified = nodbUtil.promisify(getConnection);
 
 function closeWrapper(mode, closeCb) {
   var self = this;
-
   // mode flag needs to be passed on to cpp
-  self._close(function (err) {
+  self._close({forceClose:mode}, function (err) {
     if (!err) {
       self._isValid = false;
 
@@ -229,6 +229,7 @@ function close(a1, a2) {
   if (arguments.length === 1) {
     self.closeWrapper(false, closeCb);
   } else {
+    
     //If a drainTime has been provided, it will use that value, given that connections count is not 0
     //if connectionsOut is === 0, closePool is called right away, as there is no need to wait at all.
     const drainTime = self._connectionsOut === 0 ? 0 : arguments[arguments.length - 2] * 1000;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -236,7 +236,7 @@ function close(a1, a2) {
     const upperLimitTimeout = 2147483647;
 
     nodbUtil.assert(typeof drainTime === 'number', 'NJS-006', 2);
-    nodbUtil.assert(drainTime >= 1 && drainTime <= upperLimitTimeout, 'NJS-005', 2);
+    nodbUtil.assert(drainTime >= 0 && drainTime <= upperLimitTimeout, 'NJS-005', 2);
 
     if (drainTime === 0) {
       self.closeWrapper(true, closeCb);

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -138,8 +138,7 @@ function getConnection(a1, a2) {
   var options = {};
 
   nodbUtil.assert(arguments.length >= 1 && arguments.length <= 2, 'NJS-009');
-  nodbUtil.assert(typeof getConnectionCb === 'function', 'NJS-006',
-      arguments.length);
+  nodbUtil.assert(typeof getConnectionCb === 'function', 'NJS-006', arguments.length);
   nodbUtil.assert(self.isPoolClosing === false, 'NJS-064', self.poolAlias);
 
   // Optional JSON parameter
@@ -212,9 +211,9 @@ function close(a1, a2) {
 
   const closeMode = arguments.length === 1 ? 'DPI_MODE_POOL_CLOSE_DEFAULT' : 'DPI_MODE_POOL_CLOSE_FORCE';
 
-  if(arguments.length === 1){
+  if(arguments.length === 1) {
     closePool(closeMode,closeCallback);
-  }else{
+  }else {
 
     //If a drainTime has been provided, it will use that value, given that connections count is not 0
     //if connectionsOut is === 0, closePool is called right away, as there is no need to wait at all.
@@ -227,9 +226,9 @@ function close(a1, a2) {
     nodbUtil.assert(typeof drainTime === 'number', 'NJS-006', 2);
     nodbUtil.assert(drainTime >= 1 && drainTime <= upperLimitTimeout, 'NJS-005', 2);
 
-    if(drainTime === 0 ){
+    if(drainTime === 0 ) {
       closePool(closeMode,closeCallback);
-    }else{
+    }else {
       setTimeout(() => {
         closePool(closeMode,closeCallback);
       }, drainTime);
@@ -237,7 +236,7 @@ function close(a1, a2) {
   }
 }
 
-function closePool(closeMode, closeCallback){
+function closePool(closeMode, closeCallback) {
   let self = this;
   self._isPoolClosing = true;
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -139,7 +139,7 @@ function getConnection(a1, a2) {
 
   nodbUtil.assert(arguments.length >= 1 && arguments.length <= 2, 'NJS-009');
   nodbUtil.assert(typeof getConnectionCb === 'function', 'NJS-006', arguments.length);
-  nodbUtil.assert(self.isPoolClosing === false, 'NJS-064', self.poolAlias);
+  nodbUtil.assert(self.poolClosing === false, 'NJS-064', self.poolAlias);
 
   // Optional JSON parameter
   if (arguments.length > 1 ) {
@@ -238,7 +238,7 @@ function close(a1, a2) {
 
 function closePool(closeMode, closeCallback) {
   let self = this;
-  self._isPoolClosing = true;
+  self.poolClosing = true;
 
   self._close(closeMode, (err) => {
     if (!err) {
@@ -432,7 +432,11 @@ function extend(pool, poolAttrs, poolAlias, oracledb) {
         enumerable: true,
         writable: true
       },
-      _isPoolClosing: {
+      poolClosing: {
+        get: function() {
+          return poolClosing;
+        },
+        enumerable: true,        
         value: false,
         writable: false
       }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -139,7 +139,7 @@ function getConnection(a1, a2) {
 
   nodbUtil.assert(arguments.length >= 1 && arguments.length <= 2, 'NJS-009');
   nodbUtil.assert(typeof getConnectionCb === 'function', 'NJS-006', arguments.length);
-  nodbUtil.assert(self.poolClosing === false, 'NJS-064', self.poolAlias);
+  nodbUtil.assert(self.closing === false, 'NJS-064', self.poolAlias);
 
   // Optional JSON parameter
   if (arguments.length > 1 ) {
@@ -238,7 +238,7 @@ function close(a1, a2) {
 
 function closePool(closeMode, closeCallback) {
   let self = this;
-  self.poolClosing = true;
+  self.closing = true;
 
   self._close(closeMode, (err) => {
     if (!err) {
@@ -432,9 +432,9 @@ function extend(pool, poolAttrs, poolAlias, oracledb) {
         enumerable: true,
         writable: true
       },
-      poolClosing: {
+      closing: {
         get: function() {
-          return poolClosing;
+          return closing;
         },
         enumerable: true,        
         value: false,

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -140,6 +140,7 @@ function getConnection(a1, a2) {
   nodbUtil.assert(arguments.length >= 1 && arguments.length <= 2, 'NJS-009');
   nodbUtil.assert(typeof getConnectionCb === 'function', 'NJS-006',
       arguments.length);
+  nodbUtil.assert(self.isPoolClosing === false, 'NJS-064', self.poolAlias);
 
   // Optional JSON parameter
   if (arguments.length > 1 ) {
@@ -201,22 +202,55 @@ function getConnection(a1, a2) {
 
 getConnectionPromisified = nodbUtil.promisify(getConnection);
 
-function close(closeCb) {
+
+function close(a1, a2) {
   var self = this;
+  const closeCallback = arguments[arguments.length - 1];
 
-  nodbUtil.assert(arguments.length === 1, 'NJS-009');
-  nodbUtil.assert(typeof closeCb === 'function', 'NJS-006', 1);
+  nodbUtil.assert(arguments.length !== 1 && arguments.length !== 2, 'NJS-009');  
+  nodbUtil.assert(typeof closeCallback === 'function', 'NJS-006', 1);
 
-  self._close(function(err) {
+  const closeMode = arguments.length === 1 ? 'DPI_MODE_POOL_CLOSE_DEFAULT' : 'DPI_MODE_POOL_CLOSE_FORCE';
+
+  if(arguments.length === 1){
+    closePool(closeMode,closeCallback);
+  }else{
+
+    //If a drainTime has been provided, it will use that value, given that connections count is not 0
+    //if connectionsOut is === 0, closePool is called right away, as there is no need to wait at all.
+    const drainTime = self._connectionsOut === 0 ? 0 : arguments[arguments.length - 2] * 1000;
+
+    //SetTimeout does not accept numbers greather than a 32bit signed integer.
+    const upperLimitTimeout = 2147483647;
+    
+    //test for drainTime being a number and test the 32 bit max value
+    nodbUtil.assert(typeof drainTime === 'number', 'NJS-006', 2);
+    nodbUtil.assert(drainTime >= 1 && drainTime <= upperLimitTimeout, 'NJS-005', 2);
+
+    if(drainTime === 0 ){
+      closePool(closeMode,closeCallback);
+    }else{
+      setTimeout(() => {
+        closePool(closeMode,closeCallback);
+      }, drainTime);
+    }    
+  }
+}
+
+function closePool(closeMode, closeCallback){
+  let self = this;
+  self._isPoolClosing = true;
+
+  self._close(closeMode, (err) => {
     if (!err) {
       self._isValid = false;
 
       self.emit('_after_close', self);
     }
-
-    closeCb(err);
+    closeCallback(err);
   });
 }
+
 
 closePromisified = nodbUtil.promisify(close);
 
@@ -398,6 +432,10 @@ function extend(pool, poolAttrs, poolAlias, oracledb) {
         value: closePromisified,
         enumerable: true,
         writable: true
+      },
+      _isPoolClosing: {
+        value: false,
+        writable: false
       }
     }
   );

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -204,7 +204,6 @@ getConnectionPromisified = nodbUtil.promisify(getConnection);
 
 function closeWrapper(mode, closeCb) {
   var self = this;
-  // mode flag needs to be passed on to cpp
   self._close({forceClose:mode}, function (err) {
     if (!err) {
       self._isValid = false;

--- a/lib/util.js
+++ b/lib/util.js
@@ -43,7 +43,8 @@ var errorMessages = {
   'NJS-043': 'NJS-043: ResultSet already converted to QueryStream',
   'NJS-045': 'NJS-045: cannot load the oracledb add-on binary for Node.js %s',
   'NJS-046': 'NJS-046: poolAlias "%s" already exists in the connection pool cache',
-  'NJS-047': 'NJS-047: poolAlias "%s" not found in the connection pool cache'
+  'NJS-047': 'NJS-047: poolAlias "%s" not found in the connection pool cache',
+  'NJS-064': 'NJS-064: Connection cannot be created because the connection pool "%s" is closing'
 };
 
 // makeEventEmitter is used to make class instances inherit from the EventEmitter

--- a/src/njsCommon.h
+++ b/src/njsCommon.h
@@ -336,6 +336,7 @@ public:
     Nan::Persistent<Object> jsBuffer;
     Nan::Persistent<Object> jsSubscription;
     Nan::Persistent<Function> jsCallback;
+    bool forceClose;
 
     njsBaton(Local<Function> callback, Local<Object> callingObj) :
             poolMin(0), poolMax(0), poolIncrement(0), poolTimeout(0),
@@ -355,7 +356,7 @@ public:
             rowCounts(NULL), timeout(0), qos(0), operations(0),
             numBatchErrorInfos(0), batchErrorInfos(NULL), dpiError(false),
             portNumber(0), subscrGroupingClass(0), subscrGroupingValue(0),
-            subscrGroupingType(0), subscription(NULL) {
+            subscrGroupingType(0), subscription(NULL), forceClose(false) {
         this->jsCallback.Reset(callback);
         this->jsCallingObj.Reset(callingObj);
         this->callingObj = Nan::ObjectWrap::Unwrap<njsCommon>(callingObj);

--- a/src/njsPool.cpp
+++ b/src/njsPool.cpp
@@ -455,7 +455,7 @@ NAN_METHOD(njsPool::Close)
     if (!baton)
         return;
     
-    baton->GetBoolFromJSON(info[0].As(), "forceClose", 0, &baton->forceClose);
+    baton->GetBoolFromJSON(info[0].As<Object>(), "forceClose", 0, &baton->forceClose);
     
     baton->dpiPoolHandle = pool->dpiPoolHandle;
     pool->dpiPoolHandle = NULL;

--- a/src/njsPool.cpp
+++ b/src/njsPool.cpp
@@ -446,7 +446,6 @@ NAN_METHOD(njsPool::Close)
 {
     njsBaton *baton;
     njsPool *pool;
-    bool forceClose;
 
     pool = (njsPool*) ValidateArgs(info, 2, 2);
     if (!pool)

--- a/src/njsPool.cpp
+++ b/src/njsPool.cpp
@@ -448,18 +448,14 @@ NAN_METHOD(njsPool::Close)
     njsPool *pool;
     bool forceClose;
 
-    pool = (njsPool*) ValidateArgs(info, 1, 1);
+    pool = (njsPool*) ValidateArgs(info, 2, 2);
     if (!pool)
         return;
     baton = pool->CreateBaton(info);
     if (!baton)
         return;
     
-    if (!baton->GetBoolFromJSON(info[0].As<Object>(), "forceClose", 0, &forceClose)){
-        baton->forceClose = false;
-    }else{
-        baton->forceClose = forceClose;
-    }
+    baton->GetBoolFromJSON(info[0].As(), "forceClose", 0, &baton->forceClose);
     
     baton->dpiPoolHandle = pool->dpiPoolHandle;
     pool->dpiPoolHandle = NULL;

--- a/test/pool.js
+++ b/test/pool.js
@@ -1073,7 +1073,7 @@ describe('2. pool.js', function() {
             conn1.execute("BEGIN dbms_lock.sleep(1000); END;");
           });
 
-          pool.close(100, function (err) {
+          pool.close(10, function (err) {
             should.not.exist(err);
           });
 

--- a/test/pool.js
+++ b/test/pool.js
@@ -1008,9 +1008,7 @@ describe('2. pool.js', function() {
           });
 
           pool.close(25, function (err) {
-            console.log(pool);
             should.not.exist(pool.connectionsInUse);
-            // done();
           });
 
           pool.getConnection()

--- a/test/pool.js
+++ b/test/pool.js
@@ -932,7 +932,7 @@ describe('2. pool.js', function() {
           pool.getConnection(function (err) {
             should.exist(err);
             (err.message).should.startWith('NJS-064:');
-          })
+          });
         }
       );
     });

--- a/test/pool.js
+++ b/test/pool.js
@@ -909,6 +909,33 @@ describe('2. pool.js', function() {
         }
       );
     });
+
+    it('2.10.2 close pool with force flag, and prevent new connections', function(done) {
+      oracledb.createPool(
+        {
+          user              : dbConfig.user,
+          password          : dbConfig.password,
+          connectString     : dbConfig.connectString,
+          poolMin           : 0,
+          poolMax           : 1,
+          poolIncrement     : 1,
+          poolTimeout       : 1
+        },
+        function(err, pool){
+          should.not.exist(err);
+
+          pool.close(true, function(err) {
+            should.not.exist(err);
+            done();
+          });
+
+          pool.getConnection(function (err) {
+            should.exist(err);
+            (err.message).should.startWith('NJS-064:');
+          })
+        }
+      );
+    });
   }); // 2.10
 
   describe('2.11 Invalid Credential', function() {


### PR DESCRIPTION
Added NJS-064 to util.js file
Added logic for an extra parameter in pool.js to forcibly close connection pool with DPI_MODE_POOL_CLOSE_FORCE after a timer has passed.

Signed-off-by: Danilo Henrique Garcia da Silva <danilo_hgds@hotmail.com>
