### PR TITLE
Add query config object support

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -98,7 +98,8 @@ async function run() {
       // fetchArraySize: 100       // internal buffer allocation size for tuning
     };
 
-    result = await connection.execute(sql, binds, options);
+    // You can also use a query config object to query the data
+    result = await connection.execute({ sql, binds }, options);
 
     console.log("Column metadata: ", result.metaData);
     console.log("Query results: ");

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -129,32 +129,36 @@ function execute(sql, a2, a3, a4) {
   var command;
 
   nodbUtil.assert(arguments.length > 1 && arguments.length < 5, 'NJS-009');
+  nodbUtil.assert(typeof sql === 'string' || nodbUtil.isObject(sql), 'NJS-006', 1);
 
   if (nodbUtil.isObject(sql)){
-    nodbUtil.assert(typeof sql.sql === 'string', 'NJS-006', 1);
-    nodbUtil.assert(nodbUtil.isObjectOrArray(sql.binds), 'NJS-006', 2);
-    binds = sql.binds
-    command = sql.sql
-  } else {
-    nodbUtil.assert(typeof sql === 'string', 'NJS-006', 1);
-    command = sql
+    nodbUtil.assert(typeof sql.sql === 'string', 'NJS-004', 'sql');
+    nodbUtil.assert(nodbUtil.isObjectOrArray(sql.binds), 'NJS-004', 'binds');
   }
 
   switch (arguments.length) {
     case 2:
       nodbUtil.assert(typeof a2 === 'function', 'NJS-006', 2);
+      command = sql.sql || sql;
+      binds = sql.binds || [];
       executeCb = a2;
       break;
     case 3:
       nodbUtil.assert(nodbUtil.isObjectOrArray(a2), 'NJS-006', 2);
       nodbUtil.assert(typeof a3 === 'function', 'NJS-006', 3);
-      binds = a2;
+      command = sql.sql || sql;
+      binds = sql.binds || a2;
+      if (nodbUtil.isObject(sql)) {
+        executeOpts = a2;
+      } 
       executeCb = a3;
       break;
     case 4:
+      nodbUtil.assert(typeof sql === 'string');
       nodbUtil.assert(nodbUtil.isObjectOrArray(a2), 'NJS-006', 2);
       nodbUtil.assert(nodbUtil.isObject(a3), 'NJS-006', 3);
       nodbUtil.assert(typeof a4 === 'function', 'NJS-006', 4);
+      command = sql;
       binds = a2;
       executeOpts = a3;
       executeCb = a4;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -126,9 +126,19 @@ function execute(sql, a2, a3, a4) {
   var executeOpts = {};
   var executeCb;
   var custExecuteCb;
+  var command;
 
   nodbUtil.assert(arguments.length > 1 && arguments.length < 5, 'NJS-009');
-  nodbUtil.assert(typeof sql === 'string', 'NJS-006', 1);
+
+  if (nodbUtil.isObject(sql)){
+    nodbUtil.assert(typeof sql.sql === 'string', 'NJS-006', 1);
+    nodbUtil.assert(nodbUtil.isObjectOrArray(sql.binds), 'NJS-006', 2);
+    binds = sql.binds
+    command = sql.sql
+  } else {
+    nodbUtil.assert(typeof sql === 'string', 'NJS-006', 1);
+    command = sql
+  }
 
   switch (arguments.length) {
     case 2:
@@ -184,7 +194,7 @@ function execute(sql, a2, a3, a4) {
 
   };
 
-  self._execute.call(self, sql, binds, executeOpts, custExecuteCb);
+  self._execute.call(self, command, binds, executeOpts, custExecuteCb);
 }
 
 executePromisified = nodbUtil.promisify(execute);


### PR DESCRIPTION
I would like to add [query config object](https://node-postgres.com/features/queries#query-config-object)  support to the driver (this is available in mysql drivers as well). It is very helpful to pass a query object in various situations. (e.g. something like [this](https://github.com/nearform/sql))

I couldn't see it in the code base but hopefully it may already be available.

ps: I am not sure if this is breaking any of the tests since it is very difficult for me to setup the test environment unfortunately.

Signed-off-by: cemremengu <cemremengu@gmail.com>
