### PR TITLE
Super-Low Prio: Fix typo in documentation

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -3012,7 +3012,7 @@ See [Batch Statement Execution](#batchexecution) for more information.
 
 This method was added in node-oracledb 2.2.
 
-##### <a name="executemanysqlparam"></a> 4.2.6.1 `executeMany()`: SQL Statement
+##### <a name="executemanysqlparam"></a> 4.2.7.1 `executeMany()`: SQL Statement
 
 ```
 String sql

--- a/src/njsIntLob.cpp
+++ b/src/njsIntLob.cpp
@@ -112,7 +112,7 @@ void njsILob::Init(Local<Object> target)
 
     iLobTemplate_s.Reset(tpl);
     Nan::Set(target, Nan::New<v8::String>("ILob").ToLocalChecked(),
-            tpl->GetFunction());
+            Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 

--- a/src/njsOracle.cpp
+++ b/src/njsOracle.cpp
@@ -191,7 +191,7 @@ void njsOracledb::Init(Local<Object> target)
 
     oracledbTemplate_s.Reset(temp);
     Nan::Set(target, Nan::New<v8::String>("Oracledb").ToLocalChecked(),
-            temp->GetFunction());
+            Nan::GetFunction(temp).ToLocalChecked());
 
     Local<Object> obj = Nan::New<v8::Object>();
     subscriptions.Reset(obj);

--- a/src/njsPool.cpp
+++ b/src/njsPool.cpp
@@ -107,7 +107,7 @@ void njsPool::Init(Local<Object> target)
 
     poolTemplate_s.Reset(temp);
     Nan::Set(target, Nan::New<v8::String>("Pool").ToLocalChecked(),
-            temp->GetFunction());
+            Nan::GetFunction(temp).ToLocalChecked());
 }
 
 

--- a/src/njsResultSet.cpp
+++ b/src/njsResultSet.cpp
@@ -102,7 +102,7 @@ void njsResultSet::Init(Local<Object> target)
 
     resultSetTemplate_s.Reset(temp);
     Nan::Set(target, Nan::New<v8::String>("ResultSet").ToLocalChecked(),
-            temp->GetFunction());
+            Nan::GetFunction(temp).ToLocalChecked());
 }
 
 

--- a/src/njsSodaCollection.cpp
+++ b/src/njsSodaCollection.cpp
@@ -92,7 +92,7 @@ void njsSodaCollection::Init(Local<Object> target)
 
     sodaCollTemplate_s.Reset(tpl);
     Nan::Set(target, Nan::New<v8::String>("Collection").ToLocalChecked(),
-            tpl->GetFunction());
+            Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 

--- a/src/njsSodaDatabase.cpp
+++ b/src/njsSodaDatabase.cpp
@@ -82,7 +82,7 @@ void njsSodaDatabase::Init(Local<Object> target)
 
     sodaDBTemplate_s.Reset(tpl);
     Nan::Set(target, Nan::New<v8::String>("SodaDB").ToLocalChecked(),
-            tpl->GetFunction());
+            Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 

--- a/src/njsSodaDocCursor.cpp
+++ b/src/njsSodaDocCursor.cpp
@@ -73,7 +73,7 @@ void njsSodaDocCursor::Init(Local<Object> target)
 
     sodaDocCursorTemplate_s.Reset(tpl);
     Nan::Set(target, Nan::New<v8::String>("SodaDocCursor").ToLocalChecked(),
-            tpl->GetFunction());
+            Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 

--- a/src/njsSodaDocument.cpp
+++ b/src/njsSodaDocument.cpp
@@ -99,7 +99,7 @@ void njsSodaDocument::Init(Local<Object> target)
 
     sodaDocTemplate_s.Reset(tpl);
     Nan::Set(target, Nan::New<v8::String>("Document").ToLocalChecked(),
-             tpl->GetFunction ());
+             Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 

--- a/src/njsSodaOperation.cpp
+++ b/src/njsSodaOperation.cpp
@@ -87,7 +87,7 @@ void njsSodaOperation::Init(Local<Object> target)
 
     sodaOperationTemplate_s.Reset(tpl);
     Nan::Set(target, Nan::New<v8::String>("SodaOperation").ToLocalChecked(),
-            tpl->GetFunction());
+            Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 

--- a/src/njsSubscription.cpp
+++ b/src/njsSubscription.cpp
@@ -126,7 +126,7 @@ void njsSubscription::Init(Local<Object> target)
 
     subscriptionTemplate_s.Reset(temp);
     Nan::Set(target, Nan::New<v8::String>("Subscription").ToLocalChecked(),
-            temp->GetFunction());
+            Nan::GetFunction(temp).ToLocalChecked());
 }
 
 


### PR DESCRIPTION
Take a look at [https://oracle.github.io/node-oracledb/doc/api.html#-4261-executemany-sql-statement](url)

Fix typo '4.2.6.1' to '4.2.7.1'