### PR TITLE
Fix Booleans at njsDbObject_transformFromOracle

### DIFF
--- a/src/njsConnection.c
+++ b/src/njsConnection.c
@@ -1073,6 +1073,12 @@ static bool njsConnection_getBindInfoFromValue(njsBaton *baton,
         return true;
     }
 
+    // booleans
+    if (valueType == napi_boolean) {
+        *bindType = NJS_DATATYPE_BOOLEAN;
+        return true;
+    }
+
     // dates, LOBs, buffers and arrays are all objects
     if (valueType == napi_object) {
 

--- a/src/njsDbObject.c
+++ b/src/njsDbObject.c
@@ -825,6 +825,10 @@ static bool njsDbObject_transformFromOracle(njsDbObject *obj, napi_env env,
             if (dpiLob_addRef(data->value.asLOB) < 0)
                 return njsUtils_throwErrorDPI(env, obj->type->oracleDb);
             return true;
+        case DPI_ORACLE_TYPE_BOOLEAN:
+            NJS_CHECK_NAPI(env, napi_get_boolean(env, data->value.asBoolean,
+                    value))
+            return true;
         case DPI_ORACLE_TYPE_OBJECT:
             return njsDbObject_new(typeInfo->objectType, data->value.asObject,
                     env, value);

--- a/src/njsDbObject.c
+++ b/src/njsDbObject.c
@@ -890,6 +890,13 @@ static bool njsDbObject_transformToOracle(njsDbObject *obj, napi_env env,
                 *nativeTypeNum = DPI_NATIVE_TYPE_DOUBLE;
             }
             return true;
+        
+        // handle booleans
+        case napi_boolean:
+            NJS_CHECK_NAPI(env, napi_get_value_bool(env, value,
+                (bool*) &data->value.asBoolean))
+            *nativeTypeNum = DPI_NATIVE_TYPE_BOOLEAN;
+            return true;
 
         // several types of objects are supported
         case napi_object:

--- a/src/njsModule.h
+++ b/src/njsModule.h
@@ -132,6 +132,7 @@
 #define NJS_DATATYPE_BUFFER             DPI_ORACLE_TYPE_RAW
 #define NJS_DATATYPE_CLOB               DPI_ORACLE_TYPE_CLOB
 #define NJS_DATATYPE_BLOB               DPI_ORACLE_TYPE_BLOB
+#define NJS_DATATYPE_BOOLEAN            DPI_ORACLE_TYPE_BOOLEAN
 #define NJS_DATATYPE_OBJECT             DPI_ORACLE_TYPE_OBJECT
 
 // error messages used within the driver

--- a/src/njsVariable.c
+++ b/src/njsVariable.c
@@ -239,8 +239,6 @@ uint32_t njsVariable_getDataType(njsVariable *var)
             return NJS_DATATYPE_CLOB;
         case DPI_ORACLE_TYPE_BLOB:
             return NJS_DATATYPE_BLOB;
-        case DPI_ORACLE_TYPE_BOOLEAN:
-            return NJS_DATATYPE_BOOLEAN;
         case DPI_ORACLE_TYPE_OBJECT:
             return NJS_DATATYPE_OBJECT;
         default:
@@ -541,10 +539,6 @@ bool njsVariable_initForQuery(njsVariable *vars, uint32_t numVars,
             case DPI_ORACLE_TYPE_NATIVE_FLOAT:
             case DPI_ORACLE_TYPE_NATIVE_DOUBLE:
             case DPI_ORACLE_TYPE_ROWID:
-                break;
-            case DPI_ORACLE_TYPE_BOOLEAN:
-                vars[i].varTypeNum = DPI_ORACLE_TYPE_BOOLEAN;
-                vars[i].nativeTypeNum = DPI_NATIVE_TYPE_BOOLEAN;
                 break;
             case DPI_ORACLE_TYPE_OBJECT:
                 vars[i].dpiObjectTypeHandle = queryInfo.typeInfo.objectType;

--- a/src/njsVariable.c
+++ b/src/njsVariable.c
@@ -95,6 +95,10 @@ bool njsVariable_createBuffer(njsVariable *var, njsConnection *conn,
             var->varTypeNum = DPI_ORACLE_TYPE_BLOB;
             var->nativeTypeNum = DPI_NATIVE_TYPE_LOB;
             break;
+        case NJS_DATATYPE_BOOLEAN:
+            var->varTypeNum = DPI_ORACLE_TYPE_BOOLEAN;
+            var->nativeTypeNum = DPI_NATIVE_TYPE_BOOLEAN;
+            break;
         case NJS_DATATYPE_OBJECT:
             var->varTypeNum = DPI_ORACLE_TYPE_OBJECT;
             var->nativeTypeNum = DPI_NATIVE_TYPE_OBJECT;
@@ -420,6 +424,11 @@ bool njsVariable_getScalarValue(njsVariable *var, njsVariableBuffer *buffer,
                 return njsBaton_setErrorDPI(baton);
             NJS_CHECK_NAPI(env, napi_create_string_utf8(env, rowidValue,
                     rowidValueLength, value))
+            break;
+        case DPI_NATIVE_TYPE_BOOLEAN:
+            NJS_CHECK_NAPI(env, napi_get_boolean(env,
+                        data->value.asBoolean,
+                        value))
             break;
         case DPI_NATIVE_TYPE_OBJECT:
             if (!njsDbObject_new(var->objectType, data->value.asObject,

--- a/src/njsVariable.c
+++ b/src/njsVariable.c
@@ -239,6 +239,8 @@ uint32_t njsVariable_getDataType(njsVariable *var)
             return NJS_DATATYPE_CLOB;
         case DPI_ORACLE_TYPE_BLOB:
             return NJS_DATATYPE_BLOB;
+        case DPI_ORACLE_TYPE_BOOLEAN:
+            return NJS_DATATYPE_BOOLEAN;
         case DPI_ORACLE_TYPE_OBJECT:
             return NJS_DATATYPE_OBJECT;
         default:
@@ -539,6 +541,10 @@ bool njsVariable_initForQuery(njsVariable *vars, uint32_t numVars,
             case DPI_ORACLE_TYPE_NATIVE_FLOAT:
             case DPI_ORACLE_TYPE_NATIVE_DOUBLE:
             case DPI_ORACLE_TYPE_ROWID:
+                break;
+            case DPI_ORACLE_TYPE_BOOLEAN:
+                vars[i].varTypeNum = DPI_ORACLE_TYPE_BOOLEAN;
+                vars[i].nativeTypeNum = DPI_NATIVE_TYPE_BOOLEAN;
                 break;
             case DPI_ORACLE_TYPE_OBJECT:
                 vars[i].dpiObjectTypeHandle = queryInfo.typeInfo.objectType;
@@ -945,6 +951,15 @@ bool njsVariable_setScalarValue(njsVariable *var, uint32_t pos, napi_env env,
             return njsVariable_setInvalidBind(var, pos, baton);
         NJS_CHECK_NAPI(env, napi_get_value_double(env, value,
                 &data->value.asDouble))
+        return true;
+    }
+
+    // handle binding booleans
+    if (valueType == napi_boolean) {
+        if (var->varTypeNum != DPI_ORACLE_TYPE_BOOLEAN)
+            return njsVariable_setInvalidBind(var, pos, baton);
+        NJS_CHECK_NAPI(env, napi_get_value_bool(env, value,
+                (bool*) &data->value.asBoolean))
         return true;
     }
 


### PR DESCRIPTION
1. Support 'PL/SQL BOOLEAN'  at tranformation from DBObject to Javascript values.

Signed-off-by: Diego Arce <Diego@arce.cr>

#1189 