### PR TITLE
WIP: feat: add compatibility with bun

### DIFF
--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -19,6 +19,7 @@
 
 'use strict';
 
+const path = require('path');
 const nodbUtil = require('./util.js');
 const util = require('util');
 

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -28,7 +28,11 @@ const util = require('util');
 // 12.0) contain an important Node-API performance regression fix.  If
 // you're using the obsolete Node.js 9 or 11 versions, you're on your
 // own regarding performance and functionality
-let vs = process.version.substring(1).split(".").map(Number);
+let vs =
+  (process.versions && process.versions.node
+    ? process.versions.node
+    : process.version.substring(1)
+  ).split(".").map(Number);
 if (vs[0] < 8 || (vs[0] === 8 && vs[1] < 16)) {
   throw new Error(nodbUtil.getErrorMessage('NJS-069', nodbUtil.PACKAGE_JSON_VERSION, "8.16"));
 } else if ((vs[0] === 10 && vs[1] < 16)) {
@@ -73,7 +77,8 @@ const binaryLocations = [
 let oracledbCLib;
 for (let i = 0; i < binaryLocations.length; i++) {
   try {
-    oracledbCLib = requireBinary(binaryLocations[i]);
+    const binaryLocation = path.resolve(__dirname, binaryLocations[i]);
+    oracledbCLib = requireBinary(binaryLocation);
     break;
   } catch (err) {
     if (err.code !== 'MODULE_NOT_FOUND' || i == binaryLocations.length - 1) {
@@ -81,7 +86,7 @@ for (let i = 0; i < binaryLocations.length; i++) {
       if (err.code === 'MODULE_NOT_FOUND') {
         // A binary was not found in any of the search directories.
         // Note this message may not be accurate for Webpack users since Webpack changes __dirname
-        nodeInfo = `\n  Looked for ${binaryLocations.map(x => require('path').resolve(__dirname, x)).join(', ')}\n  ${nodbUtil.getInstallURL()}\n`;
+        nodeInfo = `\n  Looked for ${binaryLocations.map(x => path.resolve(__dirname, x)).join(', ')}\n  ${nodbUtil.getInstallURL()}\n`;
       } else {
         nodeInfo = `\n  Node.js require('oracledb') error was:\n  ${err.message}\n  ${nodbUtil.getInstallHelp()}\n`;
       }


### PR DESCRIPTION
Closes #1519 

Changes

1. The preferred way to identify the node version is via `process.versions.node` (same logic is used also [here](https://github.com/oracle/node-oracledb/blob/8388891eb59a13403d607543b578f6e7aa876da8/package/install.js#L79)), there is a fallback to the old `process.version`
2. Binary path location is determined using `path.resolve` in current (node_modules) directory

Bun issues
- [x]  [Event Emitter empty object](https://github.com/oven-sh/bun/issues/1284)
- [x] [Error while attempting to load a module with require as a constant](https://github.com/oven-sh/bun/issues/1831)
- Node extension
  - [x]  [Segmentation fault when trying to call the .node extension](https://github.com/oven-sh/bun/issues/1286)
  - [Missing napi implementation:](https://github.com/oven-sh/bun/issues/158)
    - [ ] `napi_create_external`
    - [ ] `napi_get_value_external`
    - [ ] `napi_make_callback`
