### PR TITLE
feature: Support bigint parameters in thin mode

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -195,6 +195,7 @@ class Connection extends EventEmitter {
       typeof value === 'number' ||
       typeof value === 'string' ||
       typeof value === 'boolean' ||
+      typeof value === 'bigint' ||
       Array.isArray(value) ||
       Buffer.isBuffer(value) ||
       util.isDate(value) ||

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -165,7 +165,7 @@ function transformValueIn(info, value, options) {
     return value;
 
   // handle numbers
-  } else if (typeof value === 'number') {
+  } else if (typeof value === 'number' || typeof value === 'bigint') {
     checkType(info, options,
       types.DB_TYPE_NUMBER,
       types.DB_TYPE_BINARY_INTEGER,


### PR DESCRIPTION
Hello. There is a simple change which allow to pass build-in bigint type to parameters in thin node.
This allows you to pass large integers without conversion to string in js and CAST on the Oracle side.
Ex.:
```js
const {rows} = await conn.execute( 'SELECT null FROM DUAL WHERE :A = (CAST :B AS NUMBER)', {
  A: 1_000_000_000_000_001n,
  B: 1_000_000_000_000_001n.toString(),
});
equal(rows.length, 1);
```

```
Signed-off-by: Sławomir Osoba <you@example.org>
```
