### PR TITLE
feature: Update oracledb.js for additional binary path

### DIFF
--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -69,7 +69,7 @@ const defaultPoolAlias = 'default';
 let _initOracleClientArgs;
 
 // Load the Oracledb binary
-function _initCLib(arg1) {
+function _initCLib(options) {
   /*global __non_webpack_require__*/  // quieten eslint
   const requireBinary = (typeof __non_webpack_require__ === 'function') ? __non_webpack_require__ : require; // See Issue 1156
 
@@ -85,8 +85,8 @@ function _initCLib(arg1) {
     './node_modules/oracledb/' + nodbUtil.RELEASE_DIR + '/' + nodbUtil.BINARY_FILE,
     './node_modules/oracledb/' + nodbUtil.RELEASE_DIR + '/' + 'oracledb.node'
   ];
-  if (arg1 !== undefined && arg1.binaryPath !== undefined) {
-    binaryLocations.splice(0,0, arg1.binaryPath + '/' + nodbUtil.BINARY_FILE, arg1.binaryPath + '/' + 'oracledb.node')
+  if (options.binaryPath !== undefined) {
+    binaryLocations.splice(0,0, options.binaryPath + '/' + nodbUtil.BINARY_FILE, options.binaryPath + '/' + 'oracledb.node')
   }
   let oracledbCLib;
   for (let i = 0; i < binaryLocations.length; i++) {
@@ -678,11 +678,7 @@ function getPool(poolAlias) {
 function initOracleClient(arg1) {
   let options = {};
   errors.assertArgCount(arguments, 0, 1);
-  let binaryPath = undefined
   if (arg1 !== undefined) {
-    if ( arg1.binaryPath !== undefined) {
-      binaryPath = arg1.binaryPath
-    }
     errors.assertParamValue(nodbUtil.isObject(arg1), 1);
     options = {...arg1};
     errors.assertParamPropString(options, 1, "libDir");
@@ -694,7 +690,7 @@ function initOracleClient(arg1) {
     errors.throwErr(errors.ERR_THIN_CONNECTION_ALREADY_CREATED);
   }
   if (_initOracleClientArgs === undefined) {
-    const oracledbCLib = _initCLib({ binaryPath });
+    const oracledbCLib = _initCLib(arg1);
     if (options.driverName === undefined)
       options.driverName = constants.DEFAULT_DRIVER_NAME + " thk";
     if (options.errorUrl === undefined)

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -690,7 +690,7 @@ function initOracleClient(arg1) {
     errors.throwErr(errors.ERR_THIN_CONNECTION_ALREADY_CREATED);
   }
   if (_initOracleClientArgs === undefined) {
-    const oracledbCLib = _initCLib(arg1);
+    const oracledbCLib = _initCLib(options);
     if (options.driverName === undefined)
       options.driverName = constants.DEFAULT_DRIVER_NAME + " thk";
     if (options.errorUrl === undefined)

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -69,7 +69,7 @@ const defaultPoolAlias = 'default';
 let _initOracleClientArgs;
 
 // Load the Oracledb binary
-function _initCLib() {
+function _initCLib(arg1) {
   /*global __non_webpack_require__*/  // quieten eslint
   const requireBinary = (typeof __non_webpack_require__ === 'function') ? __non_webpack_require__ : require; // See Issue 1156
 
@@ -85,6 +85,9 @@ function _initCLib() {
     './node_modules/oracledb/' + nodbUtil.RELEASE_DIR + '/' + nodbUtil.BINARY_FILE,
     './node_modules/oracledb/' + nodbUtil.RELEASE_DIR + '/' + 'oracledb.node'
   ];
+  if (arg1 !== undefined && arg1.binaryPath !== undefined) {
+    binaryLocations.splice(0,0, arg1.binaryPath + '/' + nodbUtil.BINARY_FILE, arg1.binaryPath + '/' + 'oracledb.node')
+  }
   let oracledbCLib;
   for (let i = 0; i < binaryLocations.length; i++) {
     try {
@@ -675,7 +678,11 @@ function getPool(poolAlias) {
 function initOracleClient(arg1) {
   let options = {};
   errors.assertArgCount(arguments, 0, 1);
+  let binaryPath = undefined
   if (arg1 !== undefined) {
+    if ( arg1.binaryPath !== undefined) {
+      binaryPath = arg1.binaryPath
+    }
     errors.assertParamValue(nodbUtil.isObject(arg1), 1);
     options = {...arg1};
     errors.assertParamPropString(options, 1, "libDir");
@@ -687,7 +694,7 @@ function initOracleClient(arg1) {
     errors.throwErr(errors.ERR_THIN_CONNECTION_ALREADY_CREATED);
   }
   if (_initOracleClientArgs === undefined) {
-    const oracledbCLib = _initCLib();
+    const oracledbCLib = _initCLib({ binaryPath });
     if (options.driverName === undefined)
       options.driverName = constants.DEFAULT_DRIVER_NAME + " thk";
     if (options.errorUrl === undefined)


### PR DESCRIPTION
Hello, this PR is used for create additional parameter ```binaryPath``` when using ```initOracleClient()```. It's open the way to load oracledb.node from different path of inside the default node_modules folder.

Usage:
```
initOracleClient({ binaryPath: '/path/to/folder-of-storing-oracledb.node' })
```