### PR TITLE
value instanceof Date

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -259,7 +259,7 @@ class Connection extends EventEmitter {
       Array.isArray(value) ||
       nodbUtil.isVectorValue(value) ||
       Buffer.isBuffer(value) ||
-      util.types.isDate(value) ||
+      value instanceof Date ||
       value instanceof Lob ||
       value instanceof ResultSet ||
       value instanceof BaseDbObject


### PR DESCRIPTION

```
Signed-off-by: Deniz Yetiş <denizyetis56@gmail.com>
```

(node:93573) [DEP0047] DeprecationWarning: The `util.isDate` API is deprecated.


This deprecation message annoys me a lot.  I hope in the future versions it will be fixed or my pull request will be merged.  

