### PR TITLE
Fix timezone offset calculation for negative fractional offsets

### DIFF
--- a/src/njsUtils.c
+++ b/src/njsUtils.c
@@ -922,12 +922,9 @@ bool njsUtils_getDateValue(uint32_t varTypeNum, napi_env env,
     NJS_CHECK_NAPI(env, napi_create_uint32(env,
             timestamp->fsecond / (1000 * 1000), &args[7]))
     if (!useLocal) {
-        tzOffset = timestamp->tzHourOffset * 60;
-        if (tzOffset < 0) {
-            tzOffset -= timestamp->tzMinuteOffset;
-        } else {
-            tzOffset += timestamp->tzMinuteOffset;
-        }
+        // tzMinuteOffset carries the same sign as tzHourOffset (e.g. for
+        // -03:30, tzHourOffset is -3 and tzMinuteOffset is -30)
+        tzOffset = timestamp->tzHourOffset * 60 + timestamp->tzMinuteOffset;
     }
     NJS_CHECK_NAPI(env, napi_create_int32(env, tzOffset,
             &args[8]))

--- a/test/dataTypeTimestamp3.js
+++ b/test/dataTypeTimestamp3.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015, 2023, Oracle and/or its affiliates. */
+/* Copyright (c) 2015, 2026, Oracle and/or its affiliates. */
 
 /******************************************************************************
  *
@@ -128,6 +128,18 @@ describe('35. dataTypeTimestamp3.js', function() {
         binds,
         options);
       assert(typeof result.outBinds.bv, "string");
+    });
+
+    it('35.3.4 fetches fractional time zone offsets correctly', async function() {
+      // GitHub issue #1776: the minute portion of a negative time zone
+      // offset was subtracted instead of added (e.g. -03:30 became -02:30)
+      const result = await connection.execute(
+        `SELECT TIMESTAMP '2021-06-15 12:00:00.000 -03:30',
+                TIMESTAMP '2021-06-15 12:00:00.000 +05:30' FROM DUAL`);
+      assert.strictEqual(result.rows[0][0].getTime(),
+        Date.UTC(2021, 5, 15, 15, 30, 0));
+      assert.strictEqual(result.rows[0][1].getTime(),
+        Date.UTC(2021, 5, 15, 6, 30, 0));
     });
   });
 });


### PR DESCRIPTION
This PR fixes the timezone offset calculation in `src/njsUtils.c` for negative fractional offsets.

Previously, the code subtracted `tzMinuteOffset` from the total offset when `tzHourOffset` was negative. However, according to the ODPI-C documentation, `tzMinuteOffset` carries the same sign as `tzHourOffset` (e.g., for -03:30, `tzHourOffset` is -3 and `tzMinuteOffset` is -30). The old logic resulted in incorrect calculations, such as -03:30 becoming -02:30.

The fix simplifies the calculation to `tzHourOffset * 60 + tzMinuteOffset`, which correctly handles both positive and negative fractional offsets. A test case has been added to verify the fix.

Closes #1776