### PR TITLE
Update package.json to specify node < 22 (which removes the `util.isD…

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "buildpackage": "node package/buildpackage.js"
   },
   "engines": {
-    "node": ">=10.16"
+    "node": ">=10.16 <22"
   },
   "maintainers": [
     {


### PR DESCRIPTION
These functions are used by oracledb 5, and are dropped in node 22. This marks the compatibility in the `package.json`, which gives a warning. Otherwise an innocent-looking Node upgrade can cause runtime issues which is not fun.

I believe this would need to be merged into the v5.5.x mainline branch in order to target an older release major, but not sure how to accomplish that.

<!--

Thanks for contributing!

Before submitting PRs for node-oracledb you must have your signed *Oracle Contributor Agreement* accepted.  See https://oca.opensource.oracle.com

If the problem solved is small, you may find it easier to open an Issue describing the problem and its cause so we can create the fix.

**Note that the ODPI-C submodule does not accept PRs.**  Any required changes to ODPI-C should be submitted in the form of a problem description at https://github.com/oracle/odpi/issues before submitting a node-oracledb PR.

The bottom of your commit message must have the following line using your name and e-mail address as it appears in the OCA Signatories list.

```
Signed-off-by: Your Name <you@example.org>
```


This can be automatically added to pull requests by committing with:

```
git commit --signoff
````

-->
