### PR TITLE
thin: support O5LOGON for accounts that only carry a 10G password verifier

### DIFF
--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -13,6 +13,17 @@ that impact both Thin and Thick modes ('Common'), the changes that
 affect Thin mode (the default runtime behavior of node-oracledb from 6.0.0),
 and the changes that affect the optional :ref:`Thick Mode <enablingthick>`.
 
+node-oracledb v7.1.0 (unreleased)
+-----------------------------------------
+
+Thin Mode Changes
++++++++++++++++++
+
+#)  Added support for connecting to accounts whose password only carries the
+    legacy 10G (case-insensitive, DES) password verifier, matching Thick mode.
+    Previously, such connections failed with ``NJS-116``. See
+    :ref:`pwverifier`.
+
 node-oracledb `v7.0.0 <https://github.com/oracle/node-oracledb/compare/v6.10.0...v7.0.0>`__ (2 Jun 2025)
 -----------------------------------------------------------------------------------------------------------
 

--- a/doc/src/user_guide/appendix_a.rst
+++ b/doc/src/user_guide/appendix_a.rst
@@ -559,10 +559,9 @@ versions. The password verifier can be 10G (case-insensitive Oracle password
 verifier), 11G (SHA-1-based password verifier), and 12C (SHA-2-based SHA-512
 password verifier).
 
-Node-oracledb Thin mode supports password verifiers 11G and later.
-Node-oracledb Thick mode supports password verifiers 10G and later. To view
-all the password verifiers configured for the user accounts, use the following
-query:
+Node-oracledb Thin and Thick modes support password verifiers 10G and later.
+To view all the password verifiers configured for the user accounts, use the
+following query:
 
 .. code-block:: sql
 
@@ -570,10 +569,6 @@ query:
 
 The ``PASSWORD_VERSIONS`` column lists all the password verifiers that exist
 for the user.
-
-If you try to connect to any supported Oracle Database with node-oracledb Thin
-mode, but the user account is created only with the 10G password verifier,
-then the connection will fail with the :ref:`njs116` error.
 
 .. _pooldiff:
 

--- a/doc/src/user_guide/troubleshooting.rst
+++ b/doc/src/user_guide/troubleshooting.rst
@@ -152,24 +152,13 @@ NJS-116
     :summary: The first row displays the NJS-116 error message. The second row displays the probable cause for the NJS-116 error. The third row displays the possible solution to resolve the NJS-116 error.
 
     * - Message
-      - ``NJS-116: password verifier type 0x939 is not supported by node-oracledb in Thin mode.``
+      - ``NJS-116: password verifier type <verifier-type> is not supported by node-oracledb in Thin mode.``
     * - Cause
-      - Connecting to Oracle Database with node-oracledb Thin mode failed because your user account was only created with a 10G password verifier. Node-oracledb Thin mode supports password verifiers 11G and later. See :ref:`pwverifier`.
+      - Connecting to Oracle Database with node-oracledb Thin mode failed because your user account uses a password verifier that node-oracledb Thin mode does not support. Node-oracledb Thin and Thick modes support password verifiers 10G and later. See :ref:`pwverifier`.
     * - Action
-      - You can either:
-
-        - Database administrators can verify if your username only uses the 10G password verifier with this query:
-
-          .. code-block:: sql
-
-                SELECT USERNAME FROM DBA_USERS
-                WHERE ( PASSWORD_VERSIONS = '10G '
-                OR PASSWORD_VERSIONS = '10G HTTP ')
-                AND USERNAME <> 'ANONYMOUS';
-
-          If your username uses the 10G password verifier, then you need to upgrade your password verifier in Oracle Database to 11G or later to use node-oracledb Thin mode. To upgrade your password verifier, see `Finding and Resetting User Passwords That Use the 10G Password Verifier <https://www.oracle.com/pls/topic/lookup?ctx=dblatest&id=GUID-D7B09DFE-F55D-449A-8F8A-174D89936304>`__ for the detailed steps.
-
-        - Or :ref:`enable Thick mode <enablingthick>` since node-oracledb Thick mode supports password verifiers 10G and later.
+      - Reset the account's password so that Oracle Database generates a
+        password verifier supported by node-oracledb Thin mode (10G or later),
+        or :ref:`enable Thick mode <enablingthick>`.
 
 .. _oraerr:
 

--- a/lib/thin/protocol/constants.js
+++ b/lib/thin/protocol/constants.js
@@ -695,6 +695,8 @@ module.exports = {
   TNS_VERIFIER_TYPE_11G_2: 0x1b25,
   /** MultiRound SHA-512. */
   TNS_VERIFIER_TYPE_12C: 0x4815,
+  /** Legacy 10G (DES). */
+  TNS_VERIFIER_TYPE_10G: 0x939,
 
   // UDS flags
   TNS_UDS_FLAGS_IS_JSON: 0x00000100,

--- a/lib/thin/protocol/encryptDecrypt.js
+++ b/lib/thin/protocol/encryptDecrypt.js
@@ -29,6 +29,7 @@
 const { Buffer } = require('buffer');
 const crypto = require('crypto');
 const errors = require('../../errors.js');
+const constants = require('./constants.js');
 
 const MAX_PBKDF2_ITERATIONS = 100_000;
 
@@ -66,6 +67,37 @@ function resolveCipherKey(key) {
 }
 
 const _appendBuffer = Buffer.from([0x00, 0x01]);
+
+// Fixed DES key used in the first round of the legacy 10G verifier algorithm.
+const _fixedKey10G = Buffer.from('0123456789ABCDEF', 'hex');
+
+// DES-CBC (single DES, 8-byte key, IV=0, no padding). OpenSSL 3 moved single-DES
+// to the legacy provider, so we run 3DES with K1=K2=K3 (the key tripled), which
+// is equivalent to single DES and remains in the default provider.
+function _desCbc10G(key8, data) {
+  const iv = Buffer.alloc(8, 0);
+  const key24 = Buffer.concat([key8, key8, key8]);
+  const cipher = crypto.createCipheriv('des-ede3-cbc', key24, iv);
+  cipher.setAutoPadding(false);
+  return Buffer.concat([cipher.update(data), cipher.final()]);
+}
+
+// Computes the legacy 10G (DES) password verifier: the 8-byte hash Oracle stores
+// in SYS.USER$.PASSWORD. DES-CBC over UPPER(user+password) encoded as UTF-16BE and
+// zero-padded, keyed by a fixed constant; the last block becomes the key for a
+// second DES-CBC pass over the same text, whose last block is the verifier.
+function getVerifier10G(username, password) {
+  // Node has no native UTF-16BE encoding: encode UTF-16LE then swap each 16-bit
+  // word to big-endian.
+  const text = Buffer.from(String(username + password).toUpperCase(), 'utf16le');
+  text.swap16();
+  const blockSize = 8;
+  const rem = text.length % blockSize;
+  const padded = rem ?
+    Buffer.concat([text, Buffer.alloc(blockSize - rem)]) : text;
+  const interKey = _desCbc10G(_fixedKey10G, padded).subarray(-8);
+  return _desCbc10G(interKey, padded).subarray(-8);
+}
 
 /**
  * A single Instance which handles all Encrypt, Decrypt,
@@ -137,11 +169,14 @@ class EncryptDecrypt {
    * @param {object} sessionData The key/value pairs returned from OSESS key rpc
    * @param {string} password    Current Password of user
    * @param {string} newPassword New password to be updated
-   * @param {boolean} verifier11G Verifier type 11g or not(12c)
+   * @param {number} verifierType Verifier type returned by the server
    */
-  updateVerifierData(sessionData, password, newPassword, verifier11G, authObj) {
+  updateVerifierData(sessionData, password, newPassword, verifierType, authObj) {
+    const verifier11G =
+      verifierType === constants.TNS_VERIFIER_TYPE_11G_1 ||
+      verifierType === constants.TNS_VERIFIER_TYPE_11G_2;
+    const verifier10G = verifierType === constants.TNS_VERIFIER_TYPE_10G;
     let keyLen = 32;
-    let hashAlg = 'sha512';
 
     const verifierData = Buffer.from(sessionData['AUTH_VFR_DATA'], 'hex');
     const encodedServerKey = Buffer.from(sessionData['AUTH_SESSKEY'], 'hex');
@@ -151,19 +186,25 @@ class EncryptDecrypt {
 
     if (verifier11G) {
       keyLen = 24;
-      hashAlg = 'sha1';
-      const h = crypto.createHash(hashAlg);
+      const h = crypto.createHash('sha1');
       h.update(passwordBytes);
       h.update(verifierData);
       const ph = h.digest();
       passwordHash = Buffer.alloc(ph.length + 4);
       ph.copy(passwordHash, 0, 0, ph.length);
+    } else if (verifier10G) {
+      // Legacy 10G (DES): the AES-128 key is the 8-byte binary verifier padded
+      // to 16 bytes with zeros (the server derives the same key from its stored
+      // verifier). The rest of the handshake matches the 12C path.
+      keyLen = 16;
+      const verifier = getVerifier10G(authObj.username, password);
+      passwordHash = Buffer.concat([verifier, Buffer.alloc(16 - verifier.length)]);
     } else {
       const temp = Buffer.from('AUTH_PBKDF2_SPEEDY_KEY', 'utf8');
       const salt = Buffer.concat([verifierData, temp]);
       const iterations = getPBKDF2Iterations(sessionData, 'AUTH_PBKDF2_VGEN_COUNT');
       passwordKey = crypto.pbkdf2Sync(passwordBytes, salt, iterations, 64, 'sha512');
-      const h = crypto.createHash(hashAlg);
+      const h = crypto.createHash('sha512');
       h.update(passwordKey);
       h.update(verifierData);
       passwordHash = h.digest().slice(0, keyLen);
@@ -199,7 +240,9 @@ class EncryptDecrypt {
     }
 
     const salt = Buffer.alloc(16);
-    if (!verifier11G) {
+    // Only the 12C verifier sends AUTH_PBKDF2_SPEEDY_KEY (10G has no PBKDF2
+    // password key; 11G uses the MD5 session-key path).
+    if (verifierType === constants.TNS_VERIFIER_TYPE_12C) {
       crypto.randomFillSync(salt, 0, 16);
       const temp = Buffer.concat([salt, passwordKey]);
       authObj.speedyKey = this._encrypt(authObj.comboKey, temp);

--- a/lib/thin/protocol/messages/auth.js
+++ b/lib/thin/protocol/messages/auth.js
@@ -181,7 +181,6 @@ class AuthMessage extends Message {
   }
 
   encode(buf) {
-    let verifier11G = false;
     this.writeFunctionHeader(buf);
     if (this.userByteLen > 0) {
       buf.writeUInt8(1);
@@ -218,16 +217,16 @@ class AuthMessage extends Message {
             numPairs += 1;
         } else {
           numPairs += 2;
-          if (this.verifierType === constants.TNS_VERIFIER_TYPE_11G_1 ||
-          this.verifierType === constants.TNS_VERIFIER_TYPE_11G_2) {
-            verifier11G = true;
-          } else if (this.verifierType !== constants.TNS_VERIFIER_TYPE_12C) {
+          if (this.verifierType === constants.TNS_VERIFIER_TYPE_12C) {
+            numPairs += 1;   // AUTH_PBKDF2_SPEEDY_KEY
+          } else if (
+            this.verifierType !== constants.TNS_VERIFIER_TYPE_11G_1 &&
+            this.verifierType !== constants.TNS_VERIFIER_TYPE_11G_2 &&
+            this.verifierType !== constants.TNS_VERIFIER_TYPE_10G) {
             errors.throwErr(errors.ERR_UNSUPPORTED_VERIFIER_TYPE,
               this.verifierType.toString(16));
-          } else {
-            numPairs += 1;
           }
-          ED.updateVerifierData(this.sessionData, this.password, this.newPassword, verifier11G, this);
+          ED.updateVerifierData(this.sessionData, this.password, this.newPassword, this.verifierType, this);
 
           // The comboKey is cached inside the conn which is used
           // for changePassword issued on the connection
@@ -279,7 +278,7 @@ class AuthMessage extends Message {
       } else {
         if (!this.changePassword && !this.externalAuth) {
           buf.writeKeyValue("AUTH_SESSKEY", this.sessionKey, 1);
-          if (!verifier11G) {
+          if (this.verifierType === constants.TNS_VERIFIER_TYPE_12C) {
             buf.writeKeyValue("AUTH_PBKDF2_SPEEDY_KEY", this.speedyKey);
           }
         }

--- a/test/list.txt
+++ b/test/list.txt
@@ -6831,3 +6831,6 @@ Overview of node-oracledb functional tests
     328.2 quotes ORA_SDTZ values that contain SQL metacharacters
     328.3 formats the local timezone when ORA_SDTZ is not set
     328.4 formats the local timezone when ORA_SDTZ is empty
+
+  329. verifier10G.js
+    329.1 connects in Thin mode to a 10G-only password verifier account

--- a/test/opts/.mocharc.yaml
+++ b/test/opts/.mocharc.yaml
@@ -309,3 +309,4 @@ spec:
   - test/sqlAssert.js
   - test/appContext.js
   - test/securityContext.js
+  - test/verifier10G.js

--- a/test/verifier10G.js
+++ b/test/verifier10G.js
@@ -1,0 +1,76 @@
+/* Copyright (c) 2026, Oracle and/or its affiliates. */
+
+/******************************************************************************
+ *
+ * This software is dual-licensed to you under the Universal Permissive License
+ * (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl and Apache License
+ * 2.0 as shown at https://www.apache.org/licenses/LICENSE-2.0. You may choose
+ * either license.
+ *
+ * If you elect to accept the software under the Apache License, Version 2.0,
+ * the following applies:
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NAME
+ *   329. verifier10G.js
+ *
+ * DESCRIPTION
+ *   Test connecting in Thin mode to an account whose password only carries the
+ *   legacy 10G (case-insensitive, DES) password verifier.
+ *
+ *   The 10G verifier cannot be created on a default modern database instance
+ *   (it requires SEC_CASE_SENSITIVE_LOGON=FALSE), so this test is gated on a
+ *   dedicated account provided through environment variables and is skipped
+ *   when that account is not configured:
+ *
+ *     NODE_ORACLEDB_USER_10G      user whose password only has the 10G verifier
+ *     NODE_ORACLEDB_PASSWORD_10G  its password
+ *     NODE_ORACLEDB_CONNECTIONSTRING (reused from the standard test config)
+ *
+ *****************************************************************************/
+'use strict';
+
+const oracledb = require('oracledb');
+const assert = require('assert');
+const dbConfig = require('./dbconfig.js');
+
+describe('329. verifier10G.js', function() {
+
+  const user = process.env.NODE_ORACLEDB_USER_10G;
+  const password = process.env.NODE_ORACLEDB_PASSWORD_10G;
+
+  before(function() {
+    // Thick mode already supports the 10G verifier; this test targets the Thin
+    // mode O5LOGON path.
+    if (!oracledb.thin) {
+      this.skip();
+    }
+    // Skip unless a 10G-verifier account is configured.
+    if (!user || !password) {
+      this.skip();
+    }
+  });
+
+  it('329.1 connects in Thin mode to a 10G-only password verifier account', async function() {
+    const connection = await oracledb.getConnection({
+      user: user,
+      password: password,
+      connectString: dbConfig.connectString
+    });
+    const result = await connection.execute('SELECT 1 FROM dual');
+    assert.strictEqual(result.rows[0][0], 1);
+    await connection.close();
+  });
+
+});


### PR DESCRIPTION
> Resolves #1780 — https://github.com/oracle/node-oracledb/issues/1780

## Summary

In Thin mode, connecting as a user whose password only has the legacy **10G verifier**
(`AUTH_VFR_DATA` verifier type `0x939`) fails with:

```
NJS-116: password verifier type 0x939 is not supported by node-oracledb in Thin mode
```

Thick mode (via Instant Client / OCI) connects to the very same account without issue. This change
implements the same O5LOGON handshake in the Thin driver so these accounts also work in Thin mode.

## Motivation

Legacy databases (long-lived application schemas) frequently still carry only a 10G verifier, either
because `SEC_CASE_SENSITIVE_LOGON=FALSE` was used historically or because the password was never
re-hashed after an upgrade. Until now the only workarounds were to switch to Thick mode or to run
`ALTER USER ... IDENTIFIED BY ...` to regenerate the 11G/12C verifiers — not always possible when the
DBA cannot touch the account. Supporting it in Thin mode removes the Instant Client dependency for
these users.

## What changed

Three small additions, all confined to the existing verifier machinery:

1. **`lib/thin/protocol/constants.js`** — add `TNS_VERIFIER_TYPE_10G: 0x939`.
2. **`lib/thin/protocol/encryptDecrypt.js`** — add `getVerifier10G(username, password)` (and a small
   `_desCbc10G` helper) that computes the 8-byte DES verifier; add a 10G branch in `updateVerifierData`
   that derives the AES key from that verifier. `updateVerifierData` now takes the numeric
   `verifierType` (instead of the `verifier11G` boolean) so it can distinguish 10G/11G/12C.
3. **`lib/thin/protocol/messages/auth.js`**
   - Accept `0x939` in the verifier-type gate (no longer throw `NJS-116`).
   - Do not add the `AUTH_PBKDF2_SPEEDY_KEY` key/value pair for 10G (only 12C sends it).

## How the 10G O5LOGON works (thin)

The handshake is the **same O5LOGON/AES** flow already implemented for 11G/12C — only the *source of
the key material* differs:

- **Key material:** the AES-128 key is the **8-byte binary 10G verifier**, zero-padded to 16 bytes
  (`passwordHash = Buffer.concat([verifier, Buffer.alloc(8)])`). It is **not** the ASCII-hex
  representation of the verifier. The server derives the identical key from the verifier it has stored.
- **Session key:** `partA = AES-128-CBC-decrypt(AUTH_SESSKEY, passwordHash, iv=0)`; `partB` is the
  random client half; the client `AUTH_SESSKEY = AES-128-CBC-encrypt(partB, passwordHash, iv=0)`.
- **Combo key:** `PBKDF2-HMAC-SHA512(hex(partB[:16] || partA[:16]), AUTH_PBKDF2_CSK_SALT,
  AUTH_PBKDF2_SDER_COUNT, keyLen=16)` — i.e. the exact 12C combine path, only with a 16-byte key length.
- **Password:** `AUTH_PASSWORD = AES-128-CBC(comboKey, random16 || password)` — unchanged from 11G/12C.

Because the combine step is byte-for-byte identical to the existing 12C path, the 10G branch **reuses**
it (the code just selects `keyLen = 16`); no separate combine code is added.

The 10G verifier itself is `DES-CBC(DES-CBC(UPPER(user||password) as UTF-16BE, key=fixed), key=prev)`,
taking the last 8-byte block each round — the classic Oracle 10G hash.

## Node/OpenSSL note

Single-DES was moved to OpenSSL 3's **legacy provider**, so `crypto.createCipheriv('des-cbc', ...)`
throws `ERR_OSSL_EVP_UNSUPPORTED` on modern Node. The verifier is therefore computed with
`des-ede3-cbc` using the 8-byte key **tripled** (K1=K2=K3, which is exactly single DES) — this stays
in the default provider and requires **no** `--openssl-legacy-provider` flag. UTF-16BE (which Node has
no native encoding for) is produced with `Buffer.from(s, 'utf16le')` + `buf.swap16()`.

## Testing

Verified end-to-end against **Oracle Database 19c**, Thin mode, no Instant Client:

- A/B on an account carrying only the 10G verifier: stock node-oracledb 7.0.0 fails with
  `NJS-116: password verifier type 0x939 is not supported`; the patched build connects and runs
  `SELECT 1 FROM dual`.
- The DES verifier computation matches the well-known 10G hash vectors
  (`SYSTEM/MANAGER → D4DF7931AB130E37`, `SCOTT/TIGER → F894844C34402B67`).
- **Non-regression:** an account with a modern (11G/12C) verifier still connects — the change is
  confined to the 10G branch; the 11G and 12C code paths are untouched.

_TODO for the PR: add a test under `test/` gated on an environment variable pointing at a 10G-verifier
account, since the 10G verifier cannot be created on a default modern instance without
`SEC_CASE_SENSITIVE_LOGON=FALSE`._

## Security considerations

The 10G verifier is a legacy, case-insensitive DES-based hash and is considered weak. This change does
**not** create or encourage 10G verifiers; it only lets Thin mode authenticate against accounts that
already have one, matching Thick-mode behavior. Maintainers may prefer to gate it behind an opt-in
(connection attribute / environment flag) — happy to adjust. The recommended long-term fix for affected
accounts remains re-hashing the password (`ALTER USER ... IDENTIFIED BY ...`).

## Compatibility notes

- No change to any 11G/12C code path.
- No new dependency — only Node's built-in `crypto`.

## Contributor checklist

- [ ] OCA signed
- [ ] Rebased on current `main`
- [x] Test added under `test/`
- [x] CHANGELOG/docs updated
