### PR TITLE
Fix typo: UNKOWN -> UNKNOWN

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -133,7 +133,7 @@ const ERR_FETCH_TYPE_HANDLER_CONVERTER = 122;
 const ERR_CALL_TIMEOUT_EXCEEDED = 123;
 const ERR_EMPTY_CONNECT_STRING = 125;
 const ERR_OSON_VERSION_NOT_SUPPORTED = 126;
-const ERR_UNKOWN_SERVER_SIDE_PIGGYBACK = 127;
+const ERR_UNKNOWN_SERVER_SIDE_PIGGYBACK = 127;
 const ERR_UNKNOWN_COLUMN_TYPE_NAME = 128;
 const ERR_INVALID_OBJECT_TYPE_NAME = 129;
 const ERR_TDS_TYPE_NOT_SUPPORTED = 130;
@@ -474,7 +474,7 @@ messages.set(ERR_EMPTY_CONNECT_STRING,                  // NJS-125
   '"connectString" cannot be empty or undefined. Bequeath connections are not supported in Thin mode');
 messages.set(ERR_OSON_VERSION_NOT_SUPPORTED,            // NJS-126
   'OSON version %s is not supported');
-messages.set(ERR_UNKOWN_SERVER_SIDE_PIGGYBACK,          // NJS-127
+messages.set(ERR_UNKNOWN_SERVER_SIDE_PIGGYBACK,          // NJS-127
   'internal error: unknown server side piggyback opcode %s');
 messages.set(ERR_UNKNOWN_COLUMN_TYPE_NAME,              // NJS-128
   'internal error: unknown column type name "%s"');
@@ -1061,7 +1061,7 @@ module.exports = {
   ERR_FETCH_TYPE_HANDLER_CONVERTER,
   ERR_CALL_TIMEOUT_EXCEEDED,
   ERR_EMPTY_CONNECT_STRING,
-  ERR_UNKOWN_SERVER_SIDE_PIGGYBACK,
+  ERR_UNKNOWN_SERVER_SIDE_PIGGYBACK,
   ERR_UNKNOWN_COLUMN_TYPE_NAME,
   ERR_INVALID_OBJECT_TYPE_NAME,
   ERR_TDS_TYPE_NOT_SUPPORTED,


### PR DESCRIPTION
Fixes typo in error constant name: `ERR_UNKOWN_SERVER_SIDE_PIGGYBACK` → `ERR_UNKNOWN_SERVER_SIDE_PIGGYBACK` in lib/errors.js.

Thanks for maintaining this project!